### PR TITLE
[codex] Refine workspace lifecycle and pane startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,26 @@ want, use the direct CLI instead of routing through an
 agent prompt:
 
 ```bash
+npx tsx src/bin/pitch.ts --pr 700
 npx tsx src/bin/pitch.ts create --pr 700 --slug default-aas --skip-prompt
 npx tsx src/bin/pitch.ts list
 npx tsx src/bin/pitch.ts get pr-700-default-aas
 npx tsx src/bin/pitch.ts resume pr-700-default-aas
+npx tsx src/bin/pitch.ts resume pr-700-default-aas --sync
 npx tsx src/bin/pitch.ts close pr-700-default-aas
-npx tsx src/bin/pitch.ts delete pr-700-default-aas
+npx tsx src/bin/pitch.ts delete pr-700-default-aas --force
 npx tsx src/bin/pitch.ts completion zsh > ~/bin/functions/_pitch
 ```
 
 Top-level verbs are the primary interface. `workspace` is
 accepted as a compatibility alias, for example
 `npx tsx src/bin/pitch.ts workspace create ...`.
-`delete` is accepted as an alias for `close`.
+
+`close` is non-destructive: it tears down the tmux window
+and keeps the worktree as a tracked closed record.
+`delete` is destructive: it removes the workspace state
+file and, when applicable, the worktree. Dirty worktrees
+are refused unless `--force` is provided.
 
 The `completion zsh` command emits a zsh completion script
 with dynamic workspace-name completion for `get`,
@@ -169,6 +176,9 @@ defaults:
 repos:
   myorg/myrepo:
     main_worktree: ~/dev/myorg/myrepo
+    pane_commands:
+      top_right: nvim .
+      bottom_right: make build
 
 agents:
   codex:
@@ -188,6 +198,7 @@ With that config in place, the direct CLI can create a
 workspace with:
 
 ```bash
+npx tsx src/bin/pitch.ts --issue 42
 npx tsx src/bin/pitch.ts create --issue 42 --slug fix-bug
 ```
 
@@ -235,6 +246,7 @@ Each repo requires:
 | `tmux_session` | Optional explicit tmux session name for this repo |
 | `additional_paths` | Optional repo-wide extra directories Pitch translates per agent |
 | `bootstrap_prompts` | Optional repo-specific prompt template overrides for `issue` and `pr` |
+| `pane_commands` | Optional commands for the `top_right` and `bottom_right` tmux panes |
 | `agent_defaults` | Optional repo-wide agent args/env/runtime applied to every agent |
 | `agent_overrides` | Optional per-repo overrides keyed by configured agent name |
 
@@ -242,6 +254,11 @@ If `worktree_base` is omitted, Pitch derives it as
 `{defaults.worktree_root}/{owner}/{repo}`. If `tmux_session`
 is omitted, Pitch defaults it to the repo name segment
 (`kongctl` for `kong/kongctl`).
+
+If `pane_commands` are configured, Pitch sends them to the
+right-hand panes when it creates or recreates the tmux
+layout for that workspace. It does not re-run them against
+an existing live window.
 
 #### `agents`
 
@@ -404,7 +421,7 @@ Then create workspaces with the named agent entry:
 
 ```
 create_workspace \
-  --issue 42 --slug fix-bug --agent claude-personal
+  --issue 42 --agent claude-personal
 ```
 
 PR-backed workspaces use the same tool with `--pr` instead
@@ -412,14 +429,22 @@ of `--issue`:
 
 ```
 create_workspace \
-  --pr 543 --slug debug-ci --agent claude-enterprise
+  --pr 543 --agent claude-enterprise
 ```
 
 The direct CLI uses the same underlying implementation:
 
 ```bash
+npx tsx src/bin/pitch.ts --pr 543 --agent claude-enterprise
 npx tsx src/bin/pitch.ts create --pr 543 --slug debug-ci --agent claude-enterprise
 ```
+
+`slug` is optional for issue and PR creation. Without it,
+Pitch uses names like `gh-42` or `pr-543`. For PR-backed
+workspaces, the slug names the Pitch session and tmux
+window. Pitch keeps the real PR head branch checked out
+and reuses an existing tracked worktree on that branch
+when possible.
 
 ## Available Tools
 
@@ -439,12 +464,19 @@ npx tsx src/bin/pitch.ts create --pr 543 --slug debug-ci --agent claude-enterpri
 - **get_workspace** — Returns the full saved workspace
   record for a specific workspace name.
 - **resume_workspace** — Relaunches or resumes the
-  coding agent in an existing active workspace. True
-  resumes do not re-send bootstrap prompts or GitHub
-  lifecycle automation; fresh relaunches do.
-- **close_workspace** — Closes the tmux window and,
-  by default, removes the git worktree and workspace
-  state file.
+  coding agent in an existing workspace, including
+  previously closed workspaces. Resume never re-sends the
+  bootstrap prompt. With `sync: true`, PR workspaces may
+  be fast-forwarded to the latest upstream PR head before
+  the agent resumes. True resumes also skip GitHub
+  lifecycle automation; fresh relaunches may still run
+  it.
+- **close_workspace** — Closes the tmux window and marks
+  the workspace closed. The worktree and state file
+  remain so the workspace can be resumed later.
+- **delete_workspace** — Deletes a workspace by removing
+  its state file and, when applicable, its git worktree.
+  Dirty worktrees are refused unless `force` is set.
 
 ## Development
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -18,9 +18,9 @@ agent; it is a deterministic automation layer.
 
 ### What Pitch Does
 
-When a user says "create workspace for issue 565 with slug
-fix-validation" or "create workspace for PR 543 with slug
-debug-ci", Pitch:
+When a user says "create workspace for issue 565",
+"create workspace for PR 543", or adds an optional slug
+such as `fix-validation` or `debug-ci`, Pitch:
 
 1. Resolves the source work item (issue or PR)
 2. Creates or adopts the git worktree at the configured
@@ -41,11 +41,14 @@ control when the operator already knows the desired
 workspace action:
 
 ```bash
+pitch --issue 565
+pitch --pr 543
 pitch create --issue 565 --slug fix-validation
 pitch create --pr 543 --slug debug-ci
 pitch list
 pitch get pr-543-debug-ci
 pitch resume pr-543-debug-ci
+pitch resume pr-543-debug-ci --sync
 pitch close pr-543-debug-ci
 pitch delete pr-543-debug-ci
 pitch completion zsh > ~/bin/functions/_pitch
@@ -55,7 +58,6 @@ Top-level verbs are the primary interface. `pitch
 workspace <command> ...` may exist as a compatibility
 alias, but workspace lifecycle remains the default command
 surface because workspace is Pitch's primary entity.
-`delete` may exist as an alias for `close`.
 
 Shell completion may be exposed from the CLI itself,
 including dynamic completion of existing workspace names
@@ -77,9 +79,9 @@ for commands that target a workspace.
 ### Workspace
 
 A workspace is Pitch's primary entity. It represents a
-single unit of code work — one checked-out branch, one
-worktree, one tmux window, one or more sequential coding
-agent sessions.
+single unit of code work — one tmux window and one or
+more sequential coding agent sessions, backed by a
+checked-out branch and worktree.
 
 A workspace is identified by its **workspace name** (for
 example `gh-565-fix-validation` or `pr-543-debug-ci`).
@@ -98,9 +100,10 @@ work. Pitch stores the source as:
 | Relationship | Cardinality | Notes |
 |---|---|---|
 | Issue → Workspace | 1:many | Separate slugs can produce multiple workspaces |
-| PR → Workspace | 1:1 | Pitch tracks one workspace per PR |
-| Workspace → Branch | 1:1 | PR workspaces may use a branch name different from the workspace name |
+| PR → Workspace | 1:many | Multiple PR sessions may share one checkout |
+| Workspace → Branch | many:1 | PR sessions share the PR head branch |
 | Branch → Worktree | 1:1 | Git enforces this |
+| Workspace → Worktree | many:1 | PR sessions may reuse one shared checkout |
 | Workspace → tmux window | 1:1 | Window named after workspace |
 | tmux session → Repo | 1:1 | User convention, configured in Pitch |
 | Workspace → Agent sessions | 1:many | Serial — one active at a time, history tracked |
@@ -109,20 +112,19 @@ work. Pitch stores the source as:
 
 Pitch uses safe workspace names:
 
-- Issue workspace: `gh-{issue_number}-{slug}`
-- PR workspace: `pr-{pr_number}-{slug}`
+- Issue workspace: `gh-{issue_number}` or `gh-{issue_number}-{slug}`
+- PR workspace: `pr-{pr_number}` or `pr-{pr_number}-{slug}`
 
 This string is used as:
-- Worktree directory name
 - tmux window name
 - Workspace identifier in Pitch's state
 
 For issue workspaces, the git branch usually matches the
-workspace name. For PR workspaces, Pitch prefers the
-actual PR head branch name when it is not already checked
-out elsewhere. If that branch is already in use by another
-worktree, Pitch falls back to a workspace-local branch
-name so workspace creation can still proceed.
+workspace name. For PR workspaces, the slug names the
+Pitch session, while the checkout uses the actual PR head
+branch name. PR sessions may reuse an existing tracked
+worktree on that branch or create a canonical PR-scoped
+worktree such as `pr-543`.
 
 ---
 
@@ -133,7 +135,7 @@ name so workspace creation can still proceed.
 Inputs:
 - **repo** (optional, defaults from config) — e.g. `kong/kongctl`
 - **issue** or **pr** (exactly one required) — GitHub issue or PR number
-- **slug** (required) — human-provided descriptive text
+- **slug** (optional) — human-provided descriptive text
 - **base_branch** (optional, issue workspaces only, defaults to `main`)
 - **agent** (optional, defaults from config) — configured agent name such as
   `claude-enterprise`, `codex`, or `opencode`
@@ -141,22 +143,29 @@ Inputs:
 Steps:
 1. Resolve repo config (main worktree, worktree base, tmux session name)
 2. Construct workspace name:
-   `gh-{issue}-{slug}` or `pr-{pr}-{slug}`
+   `gh-{issue}` / `gh-{issue}-{slug}` or
+   `pr-{pr}` / `pr-{pr}-{slug}`
 3. Resolve the git start point:
    issue workspace from `base_branch`, or PR workspace by
    fetching `refs/pull/{pr}/head`
-4. Run `git worktree add` from the main worktree,
+4. Resolve the checkout identity:
+   issue workspaces use the workspace name; PR workspaces
+   reuse an existing tracked checkout on the PR branch
+   when available, otherwise they use a canonical
+   PR-scoped worktree name such as `pr-{pr}`
+5. Run `git worktree add` from the main worktree,
    creating or adopting the branch and worktree
-5. Check if the tmux session exists; create if not
-6. Create a tmux window named after the workspace
-7. Split into three-pane layout (agent left, empty
+6. Check if the tmux session exists; create if not
+7. Create a tmux window named after the workspace
+8. Split into three-pane layout (agent left, empty
    top-right, shell bottom-right)
-8. `cd` all panes to the worktree path
-9. Launch the coding agent in the left pane via the agent
+9. `cd` all panes to the worktree path
+10. Launch the coding agent in the left pane via the
+    agent
    launcher
-10. Persist agent session state (pre-generated for Claude,
+11. Persist agent session state (pre-generated for Claude,
     pending for Codex and OpenCode until a later backfill)
-11. Write workspace record to
+12. Write workspace record to
     `~/.pitch/workspaces/{workspace_name}.yaml`
 
 ### List
@@ -172,12 +181,29 @@ Returns full detail for a specific workspace.
 
 Relaunches the coding agent in an existing workspace's
 tmux pane, using the most recent stored session ID for the
-agent's resume command.
+agent's resume command. Closed workspaces remain tracked
+and can be resumed later.
+
+When `--sync` is requested for a PR workspace, Pitch
+fetches the latest PR head and fast-forwards the local
+branch before resuming. This is intentionally conservative:
+Pitch refuses to sync if the worktree is dirty, if a
+compatible agent pane is already running, or if the
+workspace is not PR-backed.
 
 ### Close
 
-Closes the tmux window and, by default, removes the git
-worktree and deletes the workspace state file.
+Closes the tmux window and marks the workspace closed. The
+worktree and state file remain so the workspace can be
+resumed later.
+
+### Delete
+
+Deletes a workspace record and, when applicable, its git
+worktree. Dirty worktrees are refused unless `--force` is
+set. If multiple Pitch workspaces share one PR checkout,
+Pitch deletes only the targeted workspace record and keeps
+the shared worktree.
 
 ---
 
@@ -209,8 +235,10 @@ Fixed three-pane layout per workspace:
 ```
 
 - Left pane (tall): coding agent runs here
-- Top-right: user opens nvim or whatever they want
-- Bottom-right: ad hoc command line
+- Top-right: user shell, optionally seeded by
+  `repos.<repo>.pane_commands.top_right`
+- Bottom-right: user shell, optionally seeded by
+  `repos.<repo>.pane_commands.bottom_right`
 
 All three panes `cd` to the worktree path on creation.
 
@@ -223,7 +251,7 @@ Pitch calls `git worktree add` directly. It does not depend on external worktree
 Worktree path convention:
 
 ```
-{worktree_base}/{workspace_name}
+{worktree_base}/{worktree_name}
 ```
 
 Example:
@@ -233,8 +261,10 @@ Example:
 ```
 
 The `worktree_base` is configured or derived per repo. The
-worktree path is always based on the workspace name, not
-the checked-out branch name.
+worktree path is based on the checkout identity
+(`worktree_name`), which matches the workspace name for
+issue workspaces but may be shared across multiple PR
+sessions.
 
 ---
 
@@ -396,6 +426,9 @@ repos:
   kong/kongctl:
     default_agent: claude-enterprise
     main_worktree: ~/dev/kong/kongctl
+    pane_commands:
+      top_right: nvim .
+      bottom_right: make build
     additional_paths:
       - /home/rspurgeon/go
     bootstrap_prompts:
@@ -469,6 +502,10 @@ Bootstrap prompt templates resolve in this order:
 2. top-level `bootstrap_prompts.<issue|pr>`
 3. Pitch built-in default prompt
 
+Repo pane commands run only when Pitch creates or
+recreates the tmux layout for a workspace. Pitch does not
+re-send them into an already-live window.
+
 ---
 
 ## Workspace State
@@ -477,6 +514,7 @@ Stored at `~/.pitch/workspaces/{workspace_name}.yaml`:
 
 ```yaml
 name: gh-565-fix-validation
+worktree_name: gh-565-fix-validation
 repo: kong/kongctl
 source_kind: issue
 source_number: 565
@@ -513,9 +551,11 @@ state persistence.
 
 If no workspace state file exists but the expected
 branch, worktree path, or tmux window already exists for
-the derived workspace name, Pitch adopts those matching
-resources instead of failing. Existing tracked workspaces
-are still rejected.
+the derived checkout identity, Pitch adopts those matching
+resources instead of failing. For PR workspaces, Pitch may
+also reuse an existing tracked worktree on the PR head
+branch and create an additional tmux-backed session that
+points at that shared checkout.
 
 When Pitch launches a fresh agent process, it also:
 - best-effort assigns the source issue or PR to the
@@ -534,7 +574,7 @@ bootstrap prompt into that live session.
 - exactly one of:
   - `issue` (number)
   - `pr` (number)
-- `slug` (string, required) — descriptive text for naming
+- `slug` (string, optional) — descriptive suffix for naming
 - `base_branch` (string, optional) — branch to create
   from for issue workspaces, defaults to `main`
 - `agent` (string, optional) — configured agent name like `codex`,
@@ -569,31 +609,54 @@ Returns full detail for a specific workspace.
 Relaunches the coding agent in an existing workspace, using the most recent
 session ID. For native Codex workspaces whose latest session is still pending,
 Pitch may recover the real session ID from the local Codex session store before
-falling back to a fresh launch.
+falling back to a fresh launch. Previously closed
+workspaces can also be resumed.
 
-On a true session resume, Pitch does not re-run GitHub
-lifecycle automation or re-send the bootstrap prompt. On
-a fresh relaunch fallback, it does both.
+Resume never re-sends the bootstrap prompt. On a true
+session resume, Pitch also skips GitHub lifecycle
+automation. On a fresh relaunch fallback, it may still
+re-run GitHub lifecycle automation.
+
+When `sync` is set for a PR workspace, Pitch fetches the
+latest PR head and fast-forwards the existing branch before
+resuming. Sync is refused when the worktree is dirty or a
+compatible agent pane is already running.
 
 **Parameters:**
 - `name` (string, required) — workspace name
 - `agent` (string, optional) — override agent type for this resumption
+- `environment` (string, optional) — override execution environment
+- `sync` (boolean, optional) — fast-forward a PR workspace to the latest
+  upstream PR head before resuming
 
 **Returns:** Updated workspace record with new agent session entry
 
 ### `close_workspace`
 
-Closes a workspace by tearing down its tmux window. By
-default it also removes the git worktree and deletes the
-workspace state file.
+Closes a workspace by tearing down its tmux window and
+marking it closed. The worktree and state file remain so
+the workspace can be resumed later or explicitly deleted.
 
 **Parameters:**
 - `name` (string, required) — workspace name
-- `cleanup_worktree` (boolean, optional) — if `false`,
-  keep the workspace state file and worktree as a closed
-  record; defaults to `true`
 
 **Returns:** Updated workspace record
+
+### `delete_workspace`
+
+Deletes a workspace by removing its state file and, when
+applicable, its git worktree. If the worktree is dirty,
+Pitch fails before tearing down the workspace unless
+`force` is set. If multiple Pitch workspaces share the
+same underlying checkout, Pitch only deletes the targeted
+workspace record and leaves the shared worktree in place.
+
+**Parameters:**
+- `name` (string, required) — workspace name
+- `force` (boolean, optional) — remove a dirty worktree
+  anyway
+
+**Returns:** Final closed workspace record
 
 ---
 

--- a/src/__tests__/agent-launcher.test.ts
+++ b/src/__tests__/agent-launcher.test.ts
@@ -309,6 +309,7 @@ describe("agent launcher", () => {
     const command = buildAgentResumeCommand({
       config,
       agent: "claude-enterprise",
+      workspace_name: "gh-565-fix-validation",
       session_id: "session-123",
     });
 
@@ -322,6 +323,7 @@ describe("agent launcher", () => {
     const command = buildAgentResumeCommand({
       config,
       agent: "codex",
+      workspace_name: "gh-565-fix-validation",
       session_id: "session-456",
     });
 
@@ -393,6 +395,7 @@ describe("agent launcher", () => {
       config,
       agent: "opencode",
       opencode_config_path: "/tmp/pitch-opencode/gh-565-fix-validation.json",
+      workspace_name: "gh-565-fix-validation",
       session_id: "ses_123",
       worktree_path: "/tmp/worktree",
     });
@@ -460,6 +463,7 @@ describe("agent launcher", () => {
     const command = buildAgentResumeCommand({
       config,
       agent: "opencode-attach",
+      workspace_name: "gh-565-fix-validation",
       session_id: "ses_123",
       worktree_path: "/tmp/worktree",
     });
@@ -501,6 +505,7 @@ describe("agent launcher", () => {
     const resumeCommand = buildAgentResumeCommand({
       config,
       agent: "opencode-attach-continue",
+      workspace_name: "gh-565-fix-validation",
       session_id: "ses_123",
       worktree_path: "/tmp/worktree",
     });
@@ -599,7 +604,7 @@ describe("agent launcher", () => {
     expect(command.pane_process_name).toBe("ssh");
     expect(command.pane_reuse_command).toContain("[pitch] Agent exited");
     expect(command.host_marker_path).toBe(
-      "/tmp/worktree/.pitch/vm-agent-active",
+      "/tmp/.pitch-state/gh-565-fix-validation/vm-agent-active",
     );
     expect(command.env).toEqual({});
     expect(command.agent_env).toEqual({
@@ -635,6 +640,7 @@ describe("agent launcher", () => {
     const command = buildAgentResumeCommand({
       config,
       agent: "claude-enterprise",
+      workspace_name: "gh-565-fix-validation",
       session_id: "resume-123",
       runtime: "docker",
     });
@@ -753,16 +759,19 @@ describe("agent launcher", () => {
     const claude = claudeLauncher.buildResumeCommand({
       config,
       agent: "claude-enterprise",
+      workspace_name: "gh-565-fix-validation",
       session_id: "claude-session",
     });
     const codex = codexLauncher.buildResumeCommand({
       config,
       agent: "codex",
+      workspace_name: "gh-565-fix-validation",
       session_id: "codex-session",
     });
     const opencode = opencodeLauncher.buildResumeCommand({
       config,
       agent: "opencode",
+      workspace_name: "gh-565-fix-validation",
       session_id: "ses_123",
       worktree_path: "/tmp/worktree",
     });

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -51,6 +51,7 @@ function makeWorkspaceRecord(
 ): WorkspaceRecord {
   const workspace: WorkspaceRecord = {
     name: "pr-700-default-aas",
+    worktree_name: "pr-700-default-aas",
     repo: "kong/kongctl",
     source_kind: "pr",
     source_number: 700,
@@ -84,6 +85,9 @@ function makeWorkspaceRecord(
 
   if (overrides.guest_worktree_path === undefined) {
     workspace.guest_worktree_path = workspace.worktree_path;
+  }
+  if (overrides.worktree_name === undefined) {
+    workspace.worktree_name = workspace.name;
   }
   if (overrides.environment_kind === undefined) {
     workspace.environment_kind = "host";
@@ -128,6 +132,7 @@ function makeDependencies(
     getWorkspace: vi.fn(async () => makeWorkspaceRecord()),
     resumeWorkspace: vi.fn(async () => makeWorkspaceRecord()),
     closeWorkspace: vi.fn(async () => makeWorkspaceRecord({ status: "closed" })),
+    deleteWorkspace: vi.fn(async () => makeWorkspaceRecord({ status: "closed" })),
     stdout: {
       write(chunk: string) {
         stdoutBuffer.push(chunk);
@@ -175,6 +180,114 @@ describe("runCli", () => {
     );
     expect(dependencies.stdoutBuffer.join("")).toContain(
       "name: pr-700-default-aas",
+    );
+  });
+
+  it("dispatches top-level create without a slug", async () => {
+    const dependencies = makeDependencies({
+      createWorkspace: vi.fn(async () =>
+        makeWorkspaceRecord({
+          name: "pr-700",
+          worktree_name: "pr-700",
+          worktree_path: "/tmp/worktrees/pr-700",
+          guest_worktree_path: "/tmp/worktrees/pr-700",
+          tmux_window: "pr-700",
+        })),
+    });
+
+    const exitCode = await runCli(
+      ["create", "--pr", "700"],
+      dependencies,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(dependencies.createWorkspace).toHaveBeenCalledWith(
+      {
+        repo: undefined,
+        issue: undefined,
+        pr: 700,
+        slug: undefined,
+        base_branch: undefined,
+        agent: undefined,
+        environment: undefined,
+        skip_prompt: undefined,
+        runtime: undefined,
+        model: undefined,
+      },
+      makeConfig(),
+      {
+        reportWarning: expect.any(Function),
+      },
+    );
+    expect(dependencies.stdoutBuffer.join("")).toContain(
+      "name: pr-700",
+    );
+  });
+
+  it("implies create when only create-shape flags are provided", async () => {
+    const dependencies = makeDependencies();
+
+    const exitCode = await runCli(
+      ["--pr", "700", "--slug", "default-aas", "--skip-prompt"],
+      dependencies,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(dependencies.createWorkspace).toHaveBeenCalledWith(
+      {
+        repo: undefined,
+        issue: undefined,
+        pr: 700,
+        slug: "default-aas",
+        base_branch: undefined,
+        agent: undefined,
+        environment: undefined,
+        skip_prompt: true,
+        runtime: undefined,
+        model: undefined,
+      },
+      makeConfig(),
+      {
+        reportWarning: expect.any(Function),
+      },
+    );
+  });
+
+  it("implies create when only --pr is provided", async () => {
+    const dependencies = makeDependencies({
+      createWorkspace: vi.fn(async () =>
+        makeWorkspaceRecord({
+          name: "pr-700",
+          worktree_name: "pr-700",
+          worktree_path: "/tmp/worktrees/pr-700",
+          guest_worktree_path: "/tmp/worktrees/pr-700",
+          tmux_window: "pr-700",
+        })),
+    });
+
+    const exitCode = await runCli(
+      ["--pr", "700"],
+      dependencies,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(dependencies.createWorkspace).toHaveBeenCalledWith(
+      {
+        repo: undefined,
+        issue: undefined,
+        pr: 700,
+        slug: undefined,
+        base_branch: undefined,
+        agent: undefined,
+        environment: undefined,
+        skip_prompt: undefined,
+        runtime: undefined,
+        model: undefined,
+      },
+      makeConfig(),
+      {
+        reportWarning: expect.any(Function),
+      },
     );
   });
 
@@ -265,6 +378,7 @@ describe("runCli", () => {
         name: "pr-700-default-aas",
         agent: "codex",
         environment: undefined,
+        sync: undefined,
       },
       makeConfig(),
       {
@@ -273,11 +387,34 @@ describe("runCli", () => {
     );
   });
 
-  it("supports keep-worktree for close", async () => {
+  it("passes sync through resume", async () => {
     const dependencies = makeDependencies();
 
     const exitCode = await runCli(
-      ["close", "pr-700-default-aas", "--keep-worktree"],
+      ["resume", "pr-700-default-aas", "--sync"],
+      dependencies,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(dependencies.resumeWorkspace).toHaveBeenCalledWith(
+      {
+        name: "pr-700-default-aas",
+        agent: undefined,
+        environment: undefined,
+        sync: true,
+      },
+      makeConfig(),
+      {
+        reportWarning: expect.any(Function),
+      },
+    );
+  });
+
+  it("closes a workspace without delete flags", async () => {
+    const dependencies = makeDependencies();
+
+    const exitCode = await runCli(
+      ["close", "pr-700-default-aas"],
       dependencies,
     );
 
@@ -285,25 +422,24 @@ describe("runCli", () => {
     expect(dependencies.closeWorkspace).toHaveBeenCalledWith(
       {
         name: "pr-700-default-aas",
-        cleanup_worktree: false,
       },
       makeConfig(),
     );
   });
 
-  it("accepts delete as an alias for close", async () => {
+  it("dispatches delete separately and supports force", async () => {
     const dependencies = makeDependencies();
 
     const exitCode = await runCli(
-      ["delete", "pr-700-default-aas"],
+      ["delete", "pr-700-default-aas", "--force"],
       dependencies,
     );
 
     expect(exitCode).toBe(0);
-    expect(dependencies.closeWorkspace).toHaveBeenCalledWith(
+    expect(dependencies.deleteWorkspace).toHaveBeenCalledWith(
       {
         name: "pr-700-default-aas",
-        cleanup_worktree: undefined,
+        force: true,
       },
       makeConfig(),
     );
@@ -333,17 +469,17 @@ describe("runCli", () => {
     );
   });
 
-  it("rejects the removed cleanup-worktree flag", async () => {
+  it("rejects the removed keep-worktree flag", async () => {
     const dependencies = makeDependencies();
 
     const exitCode = await runCli(
-      ["close", "pr-700-default-aas", "--cleanup-worktree"],
+      ["close", "pr-700-default-aas", "--keep-worktree"],
       dependencies,
     );
 
     expect(exitCode).toBe(1);
     expect(dependencies.stderrBuffer.join("")).toContain(
-      "pitch: Unknown option: --cleanup-worktree",
+      "pitch: Unknown option: --keep-worktree",
     );
   });
 
@@ -354,7 +490,10 @@ describe("runCli", () => {
 
     expect(exitCode).toBe(0);
     expect(dependencies.stdoutBuffer.join("")).toContain(
-      "pitch create (--issue N | --pr N) --slug SLUG [options]",
+      "pitch [create] (--issue N | --pr N) [--slug SLUG] [options]",
+    );
+    expect(dependencies.stdoutBuffer.join("")).toContain(
+      "If --issue or --pr is provided without an explicit command, create is",
     );
   });
 
@@ -372,13 +511,25 @@ describe("runCli", () => {
       "'delete[Delete a workspace]'",
     );
     expect(dependencies.stdoutBuffer.join("")).toContain(
-      "close|delete)",
+      "    close)",
+    );
+    expect(dependencies.stdoutBuffer.join("")).toContain(
+      "    delete)",
     );
     expect(dependencies.stdoutBuffer.join("")).toContain(
       "_pitch_complete_workspace_target",
     );
     expect(dependencies.stdoutBuffer.join("")).toContain(
       "_pitch_dispatch \"${words[2]}\" 2",
+    );
+    expect(dependencies.stdoutBuffer.join("")).toContain(
+      "if [[ \"${words[2]}\" == --* ]]; then",
+    );
+    expect(dependencies.stdoutBuffer.join("")).toContain(
+      "_pitch_dispatch \"create\" 1",
+    );
+    expect(dependencies.stdoutBuffer.join("")).toContain(
+      "if [[ \"${words[3]}\" == --* ]]; then",
     );
   });
 

--- a/src/__tests__/close-workspace.test.ts
+++ b/src/__tests__/close-workspace.test.ts
@@ -1,14 +1,17 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { EnsureCodexTrustedPathInput } from "../codex-trust.js";
 import type { PitchConfig } from "../config.js";
 import { GitWorktreeError } from "../git.js";
 import {
   closeWorkspace,
+  deleteWorkspace,
   CloseWorkspaceError,
-  type CloseWorkspaceDependencies,
+  DeleteWorkspaceError,
+  type WorkspaceLifecycleDependencies,
 } from "../close-workspace.js";
+import { buildVmAgentHostMarkerPath } from "../execution-environment.js";
 import type { TmuxPaneInfo } from "../tmux.js";
 import type { WorkspaceRecord } from "../workspace-state.js";
 
@@ -52,8 +55,9 @@ function makeConfig(): PitchConfig {
 function makeWorkspaceRecord(
   overrides: Partial<WorkspaceRecord> = {},
 ): WorkspaceRecord {
-  return {
+  const workspace: WorkspaceRecord = {
     name: "gh-42-fix-bug",
+    worktree_name: "gh-42-fix-bug",
     repo: "kong/kongctl",
     source_kind: "issue",
     source_number: 42,
@@ -78,11 +82,17 @@ function makeWorkspaceRecord(
     updated_at: "2026-03-22T20:30:00.000Z",
     ...overrides,
   };
+
+  if (overrides.worktree_name === undefined) {
+    workspace.worktree_name = workspace.name;
+  }
+
+  return workspace;
 }
 
 function makeDependencies(
-  overrides: Partial<CloseWorkspaceDependencies> = {},
-): CloseWorkspaceDependencies {
+  overrides: Partial<WorkspaceLifecycleDependencies> = {},
+): WorkspaceLifecycleDependencies {
   return {
     deleteOpencodeConfig: vi.fn(async () => undefined),
     deleteWorkspaceRecord: vi.fn(async () => true),
@@ -94,15 +104,21 @@ function makeDependencies(
           current_path: "/tmp/worktrees/gh-42-fix-bug",
         }) satisfies TmuxPaneInfo,
     ),
+    isWorktreeDirty: vi.fn(async () => false),
     killTmuxWindow: vi.fn(async () => true),
+    listWorkspaceRecords: vi.fn(async () => [makeWorkspaceRecord()]),
     readWorkspaceRecord: vi.fn(async () => makeWorkspaceRecord()),
-    sendKeysToPane: vi.fn(async () => undefined),
-    writeWorkspaceRecord: vi.fn(async (workspace: WorkspaceRecord) => workspace),
+    removeCodexTrustedPath: vi.fn(
+      async (_input: EnsureCodexTrustedPathInput) => undefined,
+    ),
     removeWorktree: vi.fn(async () => ({
       branch: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
     })),
-    removeCodexTrustedPath: vi.fn(async (_input: EnsureCodexTrustedPathInput) => undefined),
+    sendKeysToPane: vi.fn(async () => undefined),
+    writeWorkspaceRecord: vi.fn(
+      async (workspace: WorkspaceRecord) => workspace,
+    ),
     sleep: vi.fn(async () => undefined),
     now: vi.fn(() => new Date("2026-03-23T03:00:00.000Z")),
     ...overrides,
@@ -110,7 +126,7 @@ function makeDependencies(
 }
 
 describe("close workspace", () => {
-  it("fully cleans up the workspace by default", async () => {
+  it("closes an active workspace without deleting state or worktree", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies();
 
@@ -128,55 +144,14 @@ describe("close workspace", () => {
         updated_at: "2026-03-23T03:00:00.000Z",
       }),
     );
-    expect(dependencies.killTmuxWindow).toHaveBeenCalledWith({
-      session_name: "kongctl",
-      window_name: "gh-42-fix-bug",
-    });
     expect(dependencies.sendKeysToPane).toHaveBeenCalledWith({
       pane_id: "%1",
       command: "C-c",
       enter: false,
     });
-    expect(dependencies.removeWorktree).toHaveBeenCalledWith({
-      repo: config.repos["kong/kongctl"],
-      workspace_name: "gh-42-fix-bug",
-    });
-    expect(dependencies.deleteOpencodeConfig).toHaveBeenCalledWith(
-      "gh-42-fix-bug",
-    );
-    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
-      "gh-42-fix-bug",
-    );
-    expect(dependencies.writeWorkspaceRecord).not.toHaveBeenCalled();
-  });
-
-  it("persists a closed record when cleanup_worktree is false", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies();
-
-    const workspace = await closeWorkspace(
-      {
-        name: "gh-42-fix-bug",
-        cleanup_worktree: false,
-      },
-      config,
-      dependencies,
-    );
-
-    expect(workspace).toEqual(
-      makeWorkspaceRecord({
-        status: "closed",
-        updated_at: "2026-03-23T03:00:00.000Z",
-      }),
-    );
     expect(dependencies.killTmuxWindow).toHaveBeenCalledWith({
       session_name: "kongctl",
       window_name: "gh-42-fix-bug",
-    });
-    expect(dependencies.sendKeysToPane).toHaveBeenCalledWith({
-      pane_id: "%1",
-      command: "C-c",
-      enter: false,
     });
     expect(dependencies.writeWorkspaceRecord).toHaveBeenCalledWith(
       makeWorkspaceRecord({
@@ -184,19 +159,19 @@ describe("close workspace", () => {
         updated_at: "2026-03-23T03:00:00.000Z",
       }),
     );
-    expect(dependencies.deleteOpencodeConfig).toHaveBeenCalledWith(
-      "gh-42-fix-bug",
-    );
     expect(dependencies.removeWorktree).not.toHaveBeenCalled();
     expect(dependencies.deleteWorkspaceRecord).not.toHaveBeenCalled();
+    expect(dependencies.deleteOpencodeConfig).not.toHaveBeenCalled();
   });
 
-  it("still closes when deleting the OpenCode config fails", async () => {
+  it("is idempotent for an already closed workspace", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({
-      deleteOpencodeConfig: vi.fn(async () => {
-        throw new Error("config delete failed");
-      }),
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          status: "closed",
+        }),
+      ),
     });
 
     await expect(
@@ -210,72 +185,22 @@ describe("close workspace", () => {
     ).resolves.toEqual(
       makeWorkspaceRecord({
         status: "closed",
-        updated_at: "2026-03-23T03:00:00.000Z",
       }),
     );
-    expect(dependencies.removeWorktree).toHaveBeenCalledWith({
-      repo: config.repos["kong/kongctl"],
-      workspace_name: "gh-42-fix-bug",
-    });
-    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
-      "gh-42-fix-bug",
-    );
+    expect(dependencies.killTmuxWindow).not.toHaveBeenCalled();
     expect(dependencies.writeWorkspaceRecord).not.toHaveBeenCalled();
   });
 
-  it("treats a missing tmux window as a successful close", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      killTmuxWindow: vi.fn(async () => false),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).resolves.toEqual(
-      makeWorkspaceRecord({
-        status: "closed",
-        updated_at: "2026-03-23T03:00:00.000Z",
-      }),
-    );
-  });
-
-  it("skips graceful shutdown when pane 0 is already a shell", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      getTmuxWindowPaneInfo: vi.fn(
-        async () =>
-          ({
-            pane_id: "%1",
-            current_command: "zsh",
-            current_path: "/tmp/worktrees/gh-42-fix-bug",
-          }) satisfies TmuxPaneInfo,
-      ),
-    });
-
-    await closeWorkspace(
-      {
-        name: "gh-42-fix-bug",
-      },
-      config,
-      dependencies,
-    );
-
-    expect(dependencies.sendKeysToPane).not.toHaveBeenCalled();
-    expect(dependencies.killTmuxWindow).toHaveBeenCalled();
-  });
-
-  it("sends Ctrl-C to ssh-backed vm agent panes during graceful shutdown", async () => {
+  it("sends Ctrl-C to ssh-backed vm agent panes before closing", async () => {
     const worktreePath = await mkdtemp(
       join(process.cwd(), ".tmp-close-workspace-vm-agent-"),
     );
-    await mkdir(join(worktreePath, ".pitch"), { recursive: true });
-    await writeFile(join(worktreePath, ".pitch", "vm-agent-active"), "active");
+    const markerPath = buildVmAgentHostMarkerPath(
+      worktreePath,
+      "gh-42-fix-bug",
+    );
+    await mkdir(dirname(markerPath), { recursive: true });
+    await writeFile(markerPath, "active");
 
     const config = makeConfig();
     const dependencies = makeDependencies({
@@ -318,27 +243,7 @@ describe("close workspace", () => {
     });
   });
 
-  it("still closes the workspace when graceful shutdown inspection fails", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      getTmuxWindowPaneInfo: vi.fn(async () => {
-        throw new Error("pane inspection failed");
-      }),
-    });
-
-    await closeWorkspace(
-      {
-        name: "gh-42-fix-bug",
-      },
-      config,
-      dependencies,
-    );
-
-    expect(dependencies.sendKeysToPane).not.toHaveBeenCalled();
-    expect(dependencies.killTmuxWindow).toHaveBeenCalled();
-  });
-
-  it("errors when closing the tmux window fails", async () => {
+  it("fails when closing the tmux window fails", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({
       killTmuxWindow: vi.fn(async () => {
@@ -355,211 +260,7 @@ describe("close workspace", () => {
         dependencies,
       ),
     ).rejects.toThrow("Failed to close tmux window for gh-42-fix-bug");
-    expect(dependencies.removeWorktree).not.toHaveBeenCalled();
-    expect(dependencies.deleteWorkspaceRecord).not.toHaveBeenCalled();
-  });
-
-  it("errors when the workspace does not exist", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      readWorkspaceRecord: vi.fn(async () => null),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-404-missing",
-        },
-        config,
-        dependencies,
-      ),
-    ).rejects.toThrow("Workspace not found: gh-404-missing");
-    expect(dependencies.killTmuxWindow).not.toHaveBeenCalled();
-    expect(dependencies.deleteWorkspaceRecord).not.toHaveBeenCalled();
-  });
-
-  it("retries cleanup when the workspace record is already closed", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      readWorkspaceRecord: vi.fn(async () =>
-        makeWorkspaceRecord({
-          status: "closed",
-        }),
-      ),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).resolves.toEqual(
-      makeWorkspaceRecord({
-        status: "closed",
-      }),
-    );
-    expect(dependencies.killTmuxWindow).not.toHaveBeenCalled();
-    expect(dependencies.removeWorktree).toHaveBeenCalledWith({
-      repo: config.repos["kong/kongctl"],
-      workspace_name: "gh-42-fix-bug",
-    });
-    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
-      "gh-42-fix-bug",
-    );
     expect(dependencies.writeWorkspaceRecord).not.toHaveBeenCalled();
-  });
-
-  it("treats a missing worktree as already cleaned up", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      removeWorktree: vi.fn(async () => {
-        throw new GitWorktreeError(
-          "WORKTREE_MISSING",
-          "Worktree does not exist at /tmp/worktrees/gh-42-fix-bug",
-        );
-      }),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).resolves.toEqual(
-      makeWorkspaceRecord({
-        status: "closed",
-        updated_at: "2026-03-23T03:00:00.000Z",
-      }),
-    );
-    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
-      "gh-42-fix-bug",
-    );
-    expect(dependencies.writeWorkspaceRecord).not.toHaveBeenCalled();
-  });
-
-  it("fails cleanup when the workspace repo is no longer configured", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies();
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        {
-          ...config,
-          repos: {},
-        },
-        dependencies,
-      ),
-    ).rejects.toThrow("Repo is not configured: kong/kongctl");
-    expect(dependencies.killTmuxWindow).not.toHaveBeenCalled();
-    expect(dependencies.removeWorktree).not.toHaveBeenCalled();
-  });
-
-  it("fails when worktree cleanup fails", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      removeWorktree: vi.fn(async () => {
-        throw new Error("worktree remove failed");
-      }),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).rejects.toThrow(
-      "Failed to clean up worktree for gh-42-fix-bug: worktree remove failed",
-    );
-    expect(dependencies.deleteWorkspaceRecord).not.toHaveBeenCalled();
-    expect(dependencies.writeWorkspaceRecord).toHaveBeenCalledWith(
-      makeWorkspaceRecord({
-        status: "closed",
-        updated_at: "2026-03-23T03:00:00.000Z",
-      }),
-    );
-  });
-
-  it("reports fallback failure when worktree cleanup and closed-state write both fail", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      removeWorktree: vi.fn(async () => {
-        throw new Error("worktree remove failed");
-      }),
-      writeWorkspaceRecord: vi.fn(async () => {
-        throw new Error("fallback write failed");
-      }),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).rejects.toThrow("Fallback state write also failed: fallback write failed");
-  });
-
-  it("falls back to a persisted closed record if deleting workspace state fails", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      deleteWorkspaceRecord: vi.fn(async () => {
-        throw new Error("state delete failed");
-      }),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).rejects.toThrow(
-      "Failed to delete workspace state for gh-42-fix-bug: state delete failed",
-    );
-    expect(dependencies.writeWorkspaceRecord).toHaveBeenCalledWith(
-      makeWorkspaceRecord({
-        status: "closed",
-        updated_at: "2026-03-23T03:00:00.000Z",
-      }),
-    );
-  });
-
-  it("reports fallback failure when deleting state and fallback write both fail", async () => {
-    const config = makeConfig();
-    const dependencies = makeDependencies({
-      deleteWorkspaceRecord: vi.fn(async () => {
-        throw new Error("state delete failed");
-      }),
-      writeWorkspaceRecord: vi.fn(async () => {
-        throw new Error("fallback write failed");
-      }),
-    });
-
-    await expect(
-      closeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).rejects.toThrow("Fallback state write also failed: fallback write failed");
   });
 
   it("rejects invalid input before reading state", async () => {
@@ -575,6 +276,229 @@ describe("close workspace", () => {
         dependencies,
       ),
     ).rejects.toThrow(CloseWorkspaceError);
+    expect(dependencies.readWorkspaceRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe("delete workspace", () => {
+  it("deletes a closed workspace and its worktree by default", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          status: "closed",
+        }),
+      ),
+    });
+
+    const workspace = await deleteWorkspace(
+      {
+        name: "gh-42-fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(workspace).toEqual(
+      makeWorkspaceRecord({
+        status: "closed",
+      }),
+    );
+    expect(dependencies.isWorktreeDirty).toHaveBeenCalledWith(
+      "/tmp/worktrees/gh-42-fix-bug",
+    );
+    expect(dependencies.removeWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "gh-42-fix-bug",
+      worktree_path: "/tmp/worktrees/gh-42-fix-bug",
+      force: undefined,
+    });
+    expect(dependencies.removeCodexTrustedPath).toHaveBeenCalled();
+    expect(dependencies.deleteOpencodeConfig).toHaveBeenCalledWith(
+      "gh-42-fix-bug",
+    );
+    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
+      "gh-42-fix-bug",
+    );
+  });
+
+  it("deletes an active workspace after first persisting it as closed", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies();
+
+    await deleteWorkspace(
+      {
+        name: "gh-42-fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.killTmuxWindow).toHaveBeenCalledWith({
+      session_name: "kongctl",
+      window_name: "gh-42-fix-bug",
+    });
+    expect(dependencies.writeWorkspaceRecord).toHaveBeenCalledWith(
+      makeWorkspaceRecord({
+        status: "closed",
+        updated_at: "2026-03-23T03:00:00.000Z",
+      }),
+    );
+    expect(dependencies.removeWorktree).toHaveBeenCalled();
+    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
+      "gh-42-fix-bug",
+    );
+  });
+
+  it("removes only the session record when another workspace shares the worktree", async () => {
+    const config = makeConfig();
+    const primaryWorkspace = makeWorkspaceRecord({
+      name: "pr-690-foo-bar",
+      worktree_name: "gh-353-env-yaml-tag",
+      source_kind: "pr",
+      source_number: 690,
+      branch: "gh-353-env-yaml-tag",
+      worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+      tmux_window: "pr-690-foo-bar",
+    });
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () => primaryWorkspace),
+      listWorkspaceRecords: vi.fn(async () => [
+        primaryWorkspace,
+        makeWorkspaceRecord({
+          name: "pr-690-e2e",
+          worktree_name: "gh-353-env-yaml-tag",
+          source_kind: "pr",
+          source_number: 690,
+          branch: "gh-353-env-yaml-tag",
+          worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+          tmux_window: "pr-690-e2e",
+        }),
+      ]),
+    });
+
+    const workspace = await deleteWorkspace(
+      {
+        name: "pr-690-foo-bar",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(workspace).toEqual(
+      makeWorkspaceRecord({
+        name: "pr-690-foo-bar",
+        worktree_name: "gh-353-env-yaml-tag",
+        source_kind: "pr",
+        source_number: 690,
+        branch: "gh-353-env-yaml-tag",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        tmux_window: "pr-690-foo-bar",
+        status: "closed",
+        updated_at: "2026-03-23T03:00:00.000Z",
+      }),
+    );
+    expect(dependencies.isWorktreeDirty).not.toHaveBeenCalled();
+    expect(dependencies.removeWorktree).not.toHaveBeenCalled();
+    expect(dependencies.removeCodexTrustedPath).not.toHaveBeenCalled();
+    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
+      "pr-690-foo-bar",
+    );
+  });
+
+  it("refuses to delete a dirty worktree without force", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      isWorktreeDirty: vi.fn(async () => true),
+    });
+
+    await expect(
+      deleteWorkspace(
+        {
+          name: "gh-42-fix-bug",
+        },
+        config,
+        dependencies,
+      ),
+    ).rejects.toThrow(
+      "contains modified or untracked files; rerun with --force to delete it.",
+    );
+    expect(dependencies.killTmuxWindow).not.toHaveBeenCalled();
+    expect(dependencies.writeWorkspaceRecord).not.toHaveBeenCalled();
+    expect(dependencies.removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it("allows force deletion of a dirty worktree", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      isWorktreeDirty: vi.fn(async () => true),
+    });
+
+    await deleteWorkspace(
+      {
+        name: "gh-42-fix-bug",
+        force: true,
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.isWorktreeDirty).not.toHaveBeenCalled();
+    expect(dependencies.removeWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "gh-42-fix-bug",
+      worktree_path: "/tmp/worktrees/gh-42-fix-bug",
+      force: true,
+    });
+  });
+
+  it("treats a missing worktree as already cleaned up", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          status: "closed",
+        }),
+      ),
+      removeWorktree: vi.fn(async () => {
+        throw new GitWorktreeError(
+          "WORKTREE_MISSING",
+          "Worktree does not exist at /tmp/worktrees/gh-42-fix-bug",
+        );
+      }),
+    });
+
+    await expect(
+      deleteWorkspace(
+        {
+          name: "gh-42-fix-bug",
+        },
+        config,
+        dependencies,
+      ),
+    ).resolves.toEqual(
+      makeWorkspaceRecord({
+        status: "closed",
+      }),
+    );
+    expect(dependencies.deleteWorkspaceRecord).toHaveBeenCalledWith(
+      "gh-42-fix-bug",
+    );
+  });
+
+  it("rejects invalid input before reading state", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies();
+
+    await expect(
+      deleteWorkspace(
+        {
+          name: "",
+        },
+        config,
+        dependencies,
+      ),
+    ).rejects.toThrow(DeleteWorkspaceError);
     expect(dependencies.readWorkspaceRecord).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/close-workspace.test.ts
+++ b/src/__tests__/close-workspace.test.ts
@@ -243,6 +243,55 @@ describe("close workspace", () => {
     });
   });
 
+  it("sends Ctrl-C to ssh-backed vm agent panes when only the legacy marker exists", async () => {
+    const worktreePath = await mkdtemp(
+      join(process.cwd(), ".tmp-close-workspace-legacy-vm-agent-"),
+    );
+    const legacyMarkerPath = join(worktreePath, ".pitch", "vm-agent-active");
+    await mkdir(dirname(legacyMarkerPath), { recursive: true });
+    await writeFile(legacyMarkerPath, "active");
+
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          worktree_path: worktreePath,
+          environment_name: "sandbox-vm",
+          environment_kind: "vm-ssh",
+          guest_worktree_path: "/srv/pitch/workspaces/gh-42-fix-bug",
+          agent_pane_process: "ssh",
+        }),
+      ),
+      getTmuxWindowPaneInfo: vi.fn(
+        async () =>
+          ({
+            pane_id: "%1",
+            current_command: "ssh",
+            current_path: worktreePath,
+          }) satisfies TmuxPaneInfo,
+      ),
+    });
+
+    await closeWorkspace(
+      {
+        name: "gh-42-fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.sendKeysToPane).toHaveBeenCalledWith({
+      pane_id: "%1",
+      command: "C-c",
+      enter: false,
+    });
+
+    await rm(worktreePath, {
+      recursive: true,
+      force: true,
+    });
+  });
+
   it("fails when closing the tmux window fails", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -75,6 +75,10 @@ describe("loadConfig", () => {
         tmux_session: "kongctl",
         additional_paths: ["/home/rspurgeon/go"],
         bootstrap_prompts: {},
+        pane_commands: {
+          top_right: "nvim .",
+          bottom_right: "make build",
+        },
         agent_defaults: {
           args: [],
           env: {},
@@ -184,6 +188,7 @@ describe("loadConfig", () => {
         tmux_session: "kongctl",
         additional_paths: [],
         bootstrap_prompts: {},
+        pane_commands: {},
         agent_defaults: {
           args: [],
           env: {},

--- a/src/__tests__/create-workspace.test.ts
+++ b/src/__tests__/create-workspace.test.ts
@@ -1,3 +1,5 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { BuiltAgentCommand } from "../agent-launcher.js";
 import type { EnsureCodexTrustedPathInput } from "../codex-trust.js";
@@ -1228,6 +1230,78 @@ describe("create workspace", () => {
       repo: "kong/kongctl",
       source_kind: "issue",
       source_number: 42,
+    });
+  });
+
+  it("adopts an existing vm agent window when only the legacy marker exists", async () => {
+    const worktreePath = await mkdtemp(
+      join(process.cwd(), ".tmp-create-workspace-legacy-vm-agent-"),
+    );
+    const legacyMarkerPath = join(worktreePath, ".pitch", "vm-agent-active");
+    await mkdir(dirname(legacyMarkerPath), { recursive: true });
+    await writeFile(legacyMarkerPath, "active");
+
+    const config = makeConfig();
+    config.environments["sandbox-vm"] = {
+      kind: "vm-ssh",
+      ssh_host: "sandbox.internal",
+      ssh_user: "pitch",
+      ssh_options: [],
+      guest_workspace_root: "/srv/pitch/workspaces",
+      shared_paths: [],
+      bootstrap: {
+        mise_install: true,
+      },
+    };
+
+    const dependencies = makeDependencies({
+      ensureWorkspaceWorktree: vi.fn(async () => ({
+        branch: "gh-42-fix-bug",
+        worktree_path: worktreePath,
+        adopted: false,
+      })),
+      buildAgentStartCommand: vi.fn(() => ({
+        agent_name: "codex",
+        agent_type: "codex",
+        runtime: "native",
+        environment_name: "sandbox-vm",
+        environment_kind: "vm-ssh",
+        command: ["ssh", "-tt", "pitch@sandbox.internal"],
+        env: {},
+        agent_env: {
+          CODEX_HOME: "~/.codex",
+        },
+        pane_process_name: "ssh",
+        warnings: [],
+      }) satisfies BuiltAgentCommand),
+      tmuxWindowExists: vi.fn(async () => true),
+      getTmuxWindowPaneInfo: vi.fn(
+        async () =>
+          ({
+            pane_id: "%9",
+            current_command: "ssh",
+            current_path: worktreePath,
+          }) satisfies TmuxPaneInfo,
+      ),
+    });
+
+    const workspace = await createWorkspace(
+      {
+        issue: 42,
+        slug: "fix-bug",
+        agent: "codex",
+        environment: "sandbox-vm",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.sendKeysToPane).not.toHaveBeenCalled();
+    expect(workspace.agent_sessions).toEqual([]);
+
+    await rm(worktreePath, {
+      recursive: true,
+      force: true,
     });
   });
 

--- a/src/__tests__/create-workspace.test.ts
+++ b/src/__tests__/create-workspace.test.ts
@@ -85,6 +85,7 @@ function makeWorkspaceRecord(
 ): WorkspaceRecord {
   const workspace: WorkspaceRecord = {
     name: "gh-42-fix-bug",
+    worktree_name: "gh-42-fix-bug",
     repo: "kong/kongctl",
     source_kind: "issue",
     source_number: 42,
@@ -118,6 +119,9 @@ function makeWorkspaceRecord(
 
   if (overrides.guest_worktree_path === undefined) {
     workspace.guest_worktree_path = workspace.worktree_path;
+  }
+  if (overrides.worktree_name === undefined) {
+    workspace.worktree_name = workspace.name;
   }
   if (overrides.environment_name === undefined) {
     workspace.environment_name = null;
@@ -231,6 +235,7 @@ function makeDependencies(
       adopted: false,
     })),
     fetchGitRef: vi.fn(async () => "refs/pitch/pr/123/head"),
+    findManagedWorktreeForBranch: vi.fn(async () => null),
     removeWorktree: vi.fn(async () => ({
       branch: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
@@ -361,6 +366,102 @@ describe("create workspace", () => {
     expect(writeCallOrder).toBeLessThan(sendCallOrder);
   });
 
+  it("runs configured pane commands when creating a new tmux layout", async () => {
+    const config = makeConfig();
+    config.repos["kong/kongctl"].pane_commands = {
+      top_right: "nvim .",
+      bottom_right: "make build",
+    };
+    const dependencies = makeDependencies();
+
+    await createWorkspace(
+      {
+        issue: 42,
+        slug: "fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(1, {
+      pane_id: "%1",
+      command:
+        "CLAUDE_CONFIG_DIR=~/.claude command -- 'claude' '--model' 'opus' " +
+        "'--session-id' 'claude-session' '--name' 'gh-42-fix-bug'",
+    });
+    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(2, {
+      pane_id: "%2",
+      command: "nvim .",
+    });
+    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(3, {
+      pane_id: "%3",
+      command: "make build",
+    });
+  });
+
+  it("creates an issue workspace without a slug", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      ensureWorkspaceWorktree: vi.fn(async () => ({
+        branch: "gh-42",
+        worktree_path: "/tmp/worktrees/gh-42",
+        adopted: false,
+      })),
+      buildAgentStartCommand: vi.fn(
+        (): BuiltAgentCommand => ({
+          ...makeClaudeCommand(),
+          command: [
+            "claude",
+            "--model",
+            "sonnet",
+            "--session-id",
+            "claude-session",
+            "--name",
+            "gh-42",
+          ],
+        }),
+      ),
+    });
+
+    const workspace = await createWorkspace(
+      {
+        issue: 42,
+      },
+      config,
+      dependencies,
+    );
+
+    expect(workspace).toEqual(
+      makeWorkspaceRecord({
+        name: "gh-42",
+        worktree_name: "gh-42",
+        branch: "gh-42",
+        worktree_path: "/tmp/worktrees/gh-42",
+        guest_worktree_path: "/tmp/worktrees/gh-42",
+        tmux_window: "gh-42",
+      }),
+    );
+    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "gh-42",
+      branch: "gh-42",
+      start_point: "main",
+    });
+    expect(dependencies.buildAgentStartCommand).toHaveBeenCalledWith({
+      config,
+      agent: "claude-enterprise",
+      repo: "kong/kongctl",
+      environment: undefined,
+      opencode_config_path: undefined,
+      workspace_name: "gh-42",
+      worktree_path: "/tmp/worktrees/gh-42",
+      host_worktree_path: "/tmp/worktrees/gh-42",
+      initial_prompt: "Read issue #42 in kong/kongctl on gh-42 and wait.",
+      override_args: undefined,
+      runtime: undefined,
+    });
+  });
+
   it("skips the bootstrap prompt when skip_prompt is true", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies();
@@ -395,7 +496,7 @@ describe("create workspace", () => {
     const dependencies = makeDependencies({
       ensureWorkspaceWorktree: vi.fn(async () => ({
         branch: "feature/example",
-        worktree_path: "/tmp/worktrees/pr-123-sync-pr",
+        worktree_path: "/tmp/worktrees/pr-123",
         adopted: false,
       })),
       buildAgentStartCommand: vi.fn(
@@ -453,17 +554,19 @@ describe("create workspace", () => {
     });
     expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledWith({
       repo: config.repos["kong/kongctl"],
-      workspace_name: "pr-123-sync-pr",
+      workspace_name: "pr-123",
       branch: "feature/example",
       start_point: "refs/pitch/pr/123/head",
+      allow_branch_reuse: true,
     });
     expect(workspace).toEqual(
       makeWorkspaceRecord({
         name: "pr-123-sync-pr",
+        worktree_name: "pr-123",
         source_kind: "pr",
         source_number: 123,
         branch: "feature/example",
-        worktree_path: "/tmp/worktrees/pr-123-sync-pr",
+        worktree_path: "/tmp/worktrees/pr-123",
         tmux_window: "pr-123-sync-pr",
       }),
     );
@@ -474,8 +577,8 @@ describe("create workspace", () => {
       environment: undefined,
       opencode_config_path: undefined,
       workspace_name: "pr-123-sync-pr",
-      worktree_path: "/tmp/worktrees/pr-123-sync-pr",
-      host_worktree_path: "/tmp/worktrees/pr-123-sync-pr",
+      worktree_path: "/tmp/worktrees/pr-123",
+      host_worktree_path: "/tmp/worktrees/pr-123",
       initial_prompt: "Read repo PR #123 in kong/kongctl on feature/example and wait.",
       override_args: undefined,
       runtime: undefined,
@@ -487,60 +590,95 @@ describe("create workspace", () => {
     });
   });
 
-  it("rejects a second tracked workspace for the same PR", async () => {
+  it("creates a PR-backed workspace without a slug", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({
-      listWorkspaceRecords: vi.fn(async () => [
-        makeWorkspaceRecord({
-          name: "pr-123-existing",
-          source_kind: "pr",
-          source_number: 123,
-          branch: "feature/example",
-          worktree_path: "/tmp/worktrees/pr-123-existing",
-          tmux_window: "pr-123-existing",
+      ensureWorkspaceWorktree: vi.fn(async () => ({
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/pr-123",
+        adopted: false,
+      })),
+      buildAgentStartCommand: vi.fn(
+        (): BuiltAgentCommand => ({
+          ...makeClaudeCommand(),
+          command: [
+            "claude",
+            "--model",
+            "sonnet",
+            "--session-id",
+            "claude-session",
+            "--name",
+            "pr-123",
+          ],
         }),
-      ]),
-    });
-
-    await expect(
-      createWorkspace(
-        {
-          pr: 123,
-          slug: "other-slug",
-        },
-        config,
-        dependencies,
       ),
-    ).rejects.toThrow(
-      "PR #123 already has a tracked workspace: pr-123-existing",
-    );
-    expect(dependencies.fetchGitRef).not.toHaveBeenCalled();
-    expect(dependencies.ensureWorkspaceWorktree).not.toHaveBeenCalled();
-  });
-
-  it("falls back to the workspace branch when the PR head branch is already in use", async () => {
-    const config = makeConfig();
-    const warnings: string[] = [];
-    const dependencies = makeDependencies({
-      ensureWorkspaceWorktree: vi
-        .fn()
-        .mockRejectedValueOnce(
-          new GitWorktreeError(
-            "BRANCH_IN_USE",
-            "Branch is already checked out in another worktree: feature/example",
-          ),
-        )
-        .mockResolvedValueOnce({
-          branch: "pr-123-sync-pr",
-          worktree_path: "/tmp/worktrees/pr-123-sync-pr",
-          adopted: false,
-        }),
     });
 
     const workspace = await createWorkspace(
       {
         pr: 123,
-        slug: "sync-pr",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(workspace).toEqual(
+      makeWorkspaceRecord({
+        name: "pr-123",
+        worktree_name: "pr-123",
+        source_kind: "pr",
+        source_number: 123,
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/pr-123",
+        guest_worktree_path: "/tmp/worktrees/pr-123",
+        tmux_window: "pr-123",
+      }),
+    );
+    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "pr-123",
+      branch: "feature/example",
+      start_point: "refs/pitch/pr/123/head",
+      allow_branch_reuse: true,
+    });
+    expect(dependencies.buildAgentStartCommand).toHaveBeenCalledWith({
+      config,
+      agent: "claude-enterprise",
+      repo: "kong/kongctl",
+      environment: undefined,
+      opencode_config_path: undefined,
+      workspace_name: "pr-123",
+      worktree_path: "/tmp/worktrees/pr-123",
+      host_worktree_path: "/tmp/worktrees/pr-123",
+      initial_prompt: "Read repo PR #123 in kong/kongctl on feature/example and wait.",
+      override_args: undefined,
+      runtime: undefined,
+    });
+  });
+
+  it("reuses a tracked worktree when the PR head branch is already tracked", async () => {
+    const config = makeConfig();
+    const warnings: string[] = [];
+    const dependencies = makeDependencies({
+      listWorkspaceRecords: vi.fn(async () => [
+        makeWorkspaceRecord({
+          name: "gh-353-env-yaml-tag",
+          branch: "feature/example",
+          worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+          tmux_window: "gh-353-env-yaml-tag",
+        }),
+      ]),
+      ensureWorkspaceWorktree: vi.fn(async () => ({
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        adopted: true,
+      })),
+    });
+
+    const workspace = await createWorkspace(
+      {
+        pr: 123,
+        slug: "other-slug",
       },
       config,
       {
@@ -549,31 +687,111 @@ describe("create workspace", () => {
       },
     );
 
-    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenNthCalledWith(1, {
+    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledWith({
       repo: config.repos["kong/kongctl"],
-      workspace_name: "pr-123-sync-pr",
+      workspace_name: "gh-353-env-yaml-tag",
       branch: "feature/example",
       start_point: "refs/pitch/pr/123/head",
-    });
-    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenNthCalledWith(2, {
-      repo: config.repos["kong/kongctl"],
-      workspace_name: "pr-123-sync-pr",
-      branch: "pr-123-sync-pr",
-      start_point: "refs/pitch/pr/123/head",
+      allow_branch_reuse: true,
     });
     expect(workspace).toEqual(
       makeWorkspaceRecord({
-        name: "pr-123-sync-pr",
+        name: "pr-123-other-slug",
+        worktree_name: "gh-353-env-yaml-tag",
         source_kind: "pr",
         source_number: 123,
-        branch: "pr-123-sync-pr",
-        worktree_path: "/tmp/worktrees/pr-123-sync-pr",
-        tmux_window: "pr-123-sync-pr",
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        tmux_window: "pr-123-other-slug",
       }),
     );
     expect(warnings).toEqual([
-      "PR head branch feature/example is already checked out in another worktree; using workspace branch pr-123-sync-pr instead.",
+      "PR head branch feature/example is already tracked by workspace gh-353-env-yaml-tag; reusing worktree gh-353-env-yaml-tag.",
     ]);
+  });
+
+  it("reuses an existing managed worktree on the PR head branch even without tracked state", async () => {
+    const config = makeConfig();
+    const warnings: string[] = [];
+    const dependencies = makeDependencies({
+      findManagedWorktreeForBranch: vi.fn(async () => ({
+        workspace_name: "gh-353-env-yaml-tag",
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+      })),
+      ensureWorkspaceWorktree: vi.fn(async () => ({
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        adopted: true,
+      })),
+    });
+
+    const workspace = await createWorkspace(
+      {
+        pr: 123,
+      },
+      config,
+      {
+        ...dependencies,
+        reportWarning: (warning) => warnings.push(warning),
+      },
+    );
+
+    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "gh-353-env-yaml-tag",
+      branch: "feature/example",
+      start_point: "refs/pitch/pr/123/head",
+      allow_branch_reuse: true,
+    });
+    expect(workspace).toEqual(
+      makeWorkspaceRecord({
+        name: "pr-123",
+        worktree_name: "gh-353-env-yaml-tag",
+        source_kind: "pr",
+        source_number: 123,
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        guest_worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        tmux_window: "pr-123",
+      }),
+    );
+    expect(warnings).toEqual([
+      "PR head branch feature/example is already checked out in managed worktree gh-353-env-yaml-tag; adopting that worktree.",
+    ]);
+  });
+
+  it("surfaces a branch-in-use error when the PR head branch is already checked out elsewhere", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      ensureWorkspaceWorktree: vi.fn(async () => {
+        throw new GitWorktreeError(
+          "BRANCH_IN_USE",
+          "Branch is already checked out in another worktree: feature/example",
+        );
+      }),
+    });
+
+    await expect(
+      createWorkspace(
+        {
+          pr: 123,
+          slug: "sync-pr",
+        },
+        config,
+        dependencies,
+      ),
+    ).rejects.toThrow(
+      "Failed to create workspace pr-123-sync-pr: Branch is already checked out in another worktree: feature/example",
+    );
+    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledTimes(1);
+    expect(dependencies.ensureWorkspaceWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "pr-123",
+      branch: "feature/example",
+      start_point: "refs/pitch/pr/123/head",
+      allow_branch_reuse: true,
+    });
   });
 
   it("stores a pending Codex session and preserves shell-expanded env vars", async () => {

--- a/src/__tests__/fixtures/full-config.yaml
+++ b/src/__tests__/fixtures/full-config.yaml
@@ -10,6 +10,9 @@ repos:
     default_agent: claude-enterprise
     default_environment: sandbox-vm
     main_worktree: ~/dev/kong/kongctl
+    pane_commands:
+      top_right: nvim .
+      bottom_right: make build
     additional_paths:
       - /home/rspurgeon/go
     agent_overrides:

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -8,8 +8,11 @@ import {
   buildWorktreePath,
   createWorktree,
   ensureWorkspaceWorktree,
+  fastForwardWorktree,
   fetchGitRef,
+  findManagedWorktreeForBranch,
   GitWorktreeError,
+  listWorktreesForBranch,
   removeWorktree,
   restoreWorktree,
 } from "../git.js";
@@ -124,6 +127,28 @@ describe("git worktree management", () => {
     ).resolves.not.toContain(created.worktree_path);
   });
 
+  it("force-removes a dirty worktree", async () => {
+    const created = await createWorktree({
+      repo,
+      workspace_name: "gh-124-force-remove",
+      branch: "gh-124-force-remove",
+      start_point: "main",
+    });
+
+    await writeFile(join(created.worktree_path, "DIRTY.txt"), "dirty\n", "utf-8");
+
+    const removed = await removeWorktree({
+      repo,
+      workspace_name: "gh-124-force-remove",
+      force: true,
+    });
+
+    expect(removed).toEqual(created);
+    await expect(
+      git(["worktree", "list", "--porcelain"], repo.main_worktree),
+    ).resolves.not.toContain(created.worktree_path);
+  });
+
   it("fails gracefully when the main worktree does not exist", async () => {
     await expect(
       createWorktree({
@@ -218,6 +243,31 @@ describe("git worktree management", () => {
     ).resolves.toBe("feature/token-refresh");
   });
 
+  it("can restore a second worktree for a branch that is already checked out", async () => {
+    const existingPath = join(tempRoot, "outside-feature-token-refresh");
+    await git(
+      ["worktree", "add", "-b", "feature/token-refresh", existingPath, "main"],
+      repo.main_worktree,
+    );
+
+    const ensured = await ensureWorkspaceWorktree({
+      repo,
+      workspace_name: "pr-543-debug-ci",
+      branch: "feature/token-refresh",
+      start_point: "main",
+      allow_branch_reuse: true,
+    });
+
+    expect(ensured).toEqual({
+      branch: "feature/token-refresh",
+      worktree_path: join(repo.worktree_base, "pr-543-debug-ci"),
+      adopted: true,
+    });
+    await expect(
+      git(["rev-parse", "--abbrev-ref", "HEAD"], ensured.worktree_path),
+    ).resolves.toBe("feature/token-refresh");
+  });
+
   it("surfaces a typed error when the target branch is already checked out elsewhere", async () => {
     await git(["checkout", "-b", "feature/in-use"], repo.main_worktree);
 
@@ -232,6 +282,69 @@ describe("git worktree management", () => {
       name: "GitWorktreeError",
       code: "BRANCH_IN_USE",
     });
+  });
+
+  it("finds a managed worktree for a checked-out branch", async () => {
+    const created = await createWorktree({
+      repo,
+      workspace_name: "gh-353-env-yaml-tag",
+      branch: "gh-353-env-yaml-tag",
+      start_point: "main",
+    });
+
+    await git(
+      ["branch", "-m", "gh-353-env-yaml-tag", "feature/example"],
+      created.worktree_path,
+    );
+
+    await expect(
+      findManagedWorktreeForBranch(repo, "feature/example"),
+    ).resolves.toEqual({
+      workspace_name: "gh-353-env-yaml-tag",
+      branch: "feature/example",
+      worktree_path: join(repo.worktree_base, "gh-353-env-yaml-tag"),
+    });
+  });
+
+  it("lists all worktrees currently checking out a branch", async () => {
+    await createWorktree({
+      repo,
+      workspace_name: "pr-543-debug-ci",
+      branch: "feature/token-refresh",
+      start_point: "main",
+    });
+    await ensureWorkspaceWorktree({
+      repo,
+      workspace_name: "pr-543-e2e",
+      branch: "feature/token-refresh",
+      start_point: "main",
+      allow_branch_reuse: true,
+    });
+
+    await expect(
+      listWorktreesForBranch(repo, "feature/token-refresh"),
+    ).resolves.toEqual([
+      {
+        branch: "feature/token-refresh",
+        worktree_path: join(repo.worktree_base, "pr-543-debug-ci"),
+      },
+      {
+        branch: "feature/token-refresh",
+        worktree_path: join(repo.worktree_base, "pr-543-e2e"),
+      },
+    ]);
+  });
+
+  it("ignores branch worktrees that live outside the managed worktree base", async () => {
+    const outsidePath = join(tempRoot, "outside-feature-example");
+    await git(
+      ["worktree", "add", "-b", "feature/outside", outsidePath, "main"],
+      repo.main_worktree,
+    );
+
+    await expect(
+      findManagedWorktreeForBranch(repo, "feature/outside"),
+    ).resolves.toBeNull();
   });
 
   it("normalizes configured and registered worktree paths before adoption", async () => {
@@ -437,5 +550,42 @@ describe("git worktree management", () => {
     await expect(
       git(["show-ref", "--verify", "refs/pitch/test/main"], repo.main_worktree),
     ).resolves.toContain("refs/pitch/test/main");
+  });
+
+  it("fast-forwards a worktree to a newer target ref", async () => {
+    await git(["branch", "feature/sync", "main"], repo.main_worktree);
+
+    const worktree = await ensureWorkspaceWorktree({
+      repo,
+      workspace_name: "pr-690",
+      branch: "feature/sync",
+      start_point: "main",
+    });
+
+    const targetPath = join(tempRoot, "feature-sync-target");
+    await git(
+      ["worktree", "add", "-b", "feature/sync-target", targetPath, "feature/sync"],
+      repo.main_worktree,
+    );
+    await writeFile(join(targetPath, "SYNC.txt"), "updated\n", "utf-8");
+    await git(["add", "SYNC.txt"], targetPath);
+    await git(["commit", "-m", "sync target"], targetPath);
+
+    await fastForwardWorktree({
+      worktree_path: worktree.worktree_path,
+      target_ref: "feature/sync-target",
+    });
+
+    await expect(
+      git(["rev-parse", "--abbrev-ref", "HEAD"], worktree.worktree_path),
+    ).resolves.toBe("feature/sync");
+    await expect(
+      git(["status", "--short"], worktree.worktree_path),
+    ).resolves.toBe("");
+    await expect(
+      git(["rev-parse", "feature/sync"], repo.main_worktree),
+    ).resolves.toBe(
+      await git(["rev-parse", "feature/sync-target"], repo.main_worktree),
+    );
   });
 });

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -127,6 +127,39 @@ describe("git worktree management", () => {
     ).resolves.not.toContain(created.worktree_path);
   });
 
+  it("rejects an explicit worktree path that does not match the managed workspace path", async () => {
+    await createWorktree({
+      repo,
+      workspace_name: "gh-124-remove-worktree",
+      branch: "gh-124-remove-worktree",
+      start_point: "main",
+    });
+    const other = await createWorktree({
+      repo,
+      workspace_name: "gh-124-other-worktree",
+      branch: "gh-124-other-worktree",
+      start_point: "main",
+    });
+
+    await expect(
+      removeWorktree({
+        repo,
+        workspace_name: "gh-124-remove-worktree",
+        worktree_path: other.worktree_path,
+      }),
+    ).rejects.toMatchObject({
+      name: "GitWorktreeError",
+      code: "INVALID_WORKTREE_PATH",
+    });
+
+    await expect(
+      git(["worktree", "list", "--porcelain"], repo.main_worktree),
+    ).resolves.toContain(other.worktree_path);
+    await expect(
+      git(["worktree", "list", "--porcelain"], repo.main_worktree),
+    ).resolves.toContain(buildWorktreePath(repo, "gh-124-remove-worktree"));
+  });
+
   it("force-removes a dirty worktree", async () => {
     const created = await createWorktree({
       repo,

--- a/src/__tests__/resume-workspace.test.ts
+++ b/src/__tests__/resume-workspace.test.ts
@@ -1,3 +1,5 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { BuiltAgentCommand } from "../agent-launcher.js";
 import type { EnsureCodexTrustedPathInput } from "../codex-trust.js";
@@ -621,6 +623,72 @@ describe("resume workspace", () => {
     expect(dependencies.sendKeysToPane).not.toHaveBeenCalled();
     expect(workspace).toEqual(originalWorkspace);
     expect(dependencies.runGitHubLifecycle).not.toHaveBeenCalled();
+  });
+
+  it("treats the legacy vm agent marker as an active running agent", async () => {
+    const worktreePath = await mkdtemp(
+      join(process.cwd(), ".tmp-resume-workspace-legacy-vm-agent-"),
+    );
+    const legacyMarkerPath = join(worktreePath, ".pitch", "vm-agent-active");
+    await mkdir(dirname(legacyMarkerPath), { recursive: true });
+    await writeFile(legacyMarkerPath, "active");
+
+    const config = makeConfig();
+    config.environments["sandbox-vm"] = {
+      kind: "vm-ssh",
+      ssh_host: "sandbox.internal",
+      ssh_user: "pitch",
+      ssh_options: [],
+      guest_workspace_root: "/srv/pitch/workspaces",
+      shared_paths: [],
+      bootstrap: {
+        mise_install: true,
+      },
+    };
+
+    const originalWorkspace = makeWorkspaceRecord({
+      agent_name: "codex",
+      agent_type: "codex",
+      agent_sessions: [],
+      environment_name: "sandbox-vm",
+      environment_kind: "vm-ssh",
+      worktree_path: worktreePath,
+      guest_worktree_path: "/srv/pitch/workspaces/gh-42-fix-bug",
+      agent_pane_process: "ssh",
+    });
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () => originalWorkspace),
+      restoreWorktree: vi.fn(async () => ({
+        branch: "gh-42-fix-bug",
+        worktree_path: worktreePath,
+      })),
+      getTmuxWindowPaneInfo: vi.fn(
+        async () =>
+          ({
+            pane_id: "%1",
+            current_command: "ssh",
+            current_path: worktreePath,
+          }) satisfies TmuxPaneInfo,
+      ),
+    });
+
+    const workspace = await resumeWorkspace(
+      {
+        name: "gh-42-fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.buildAgentResumeCommand).not.toHaveBeenCalled();
+    expect(dependencies.buildAgentStartCommand).not.toHaveBeenCalled();
+    expect(dependencies.sendKeysToPane).not.toHaveBeenCalled();
+    expect(workspace).toEqual(originalWorkspace);
+
+    await rm(worktreePath, {
+      recursive: true,
+      force: true,
+    });
   });
 
   it("reuses an existing ssh pane for a vm-backed fresh launch", async () => {

--- a/src/__tests__/resume-workspace.test.ts
+++ b/src/__tests__/resume-workspace.test.ts
@@ -83,6 +83,7 @@ function makeWorkspaceRecord(
 ): WorkspaceRecord {
   const workspace: WorkspaceRecord = {
     name: "gh-42-fix-bug",
+    worktree_name: "gh-42-fix-bug",
     repo: "kong/kongctl",
     source_kind: "issue",
     source_number: 42,
@@ -116,6 +117,9 @@ function makeWorkspaceRecord(
 
   if (overrides.guest_worktree_path === undefined) {
     workspace.guest_worktree_path = workspace.worktree_path;
+  }
+  if (overrides.worktree_name === undefined) {
+    workspace.worktree_name = workspace.name;
   }
   if (overrides.environment_name === undefined) {
     workspace.environment_name = null;
@@ -248,6 +252,8 @@ function makeDependencies(
       session_name: "kongctl",
       created: false,
     })),
+    fastForwardWorktree: vi.fn(async () => undefined),
+    fetchGitRef: vi.fn(async () => "refs/pitch/pr/42/head"),
     findCodexSessionForWorkspace: vi.fn(async () => null),
     findOpencodeSessionForWorkspace: vi.fn(async () => null),
     getTmuxWindowPaneInfo: vi.fn(
@@ -267,6 +273,18 @@ function makeDependencies(
           current_path: "/tmp/worktrees/gh-42-fix-bug",
         }) satisfies TmuxPaneInfo,
     ),
+    isWorktreeDirty: vi.fn(async () => false),
+    listWorktreesForBranch: vi.fn(async () => []),
+    readPullRequest: vi.fn(async () => ({
+      number: 42,
+      title: "Example PR",
+      state: "OPEN",
+      base_ref_name: "main",
+      head_ref_name: "feature/example",
+      head_ref_oid: "abc123",
+      is_cross_repository: false,
+      url: "https://github.com/example/repo/pull/42",
+    })),
     readWorkspaceRecord: vi.fn(async () => makeWorkspaceRecord()),
     restoreWorktree: vi.fn(async () => ({
       branch: "gh-42-fix-bug",
@@ -303,6 +321,7 @@ describe("resume workspace", () => {
       agent: "claude-enterprise",
       repo: "kong/kongctl",
       environment: undefined,
+      workspace_name: "gh-42-fix-bug",
       opencode_config_path: undefined,
       session_id: "claude-session-1",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
@@ -351,6 +370,187 @@ describe("resume workspace", () => {
     );
   });
 
+  it("restores a shared PR session using the underlying worktree name", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          name: "pr-690-e2e",
+          worktree_name: "gh-353-env-yaml-tag",
+          source_kind: "pr",
+          source_number: 690,
+          branch: "gh-353-env-yaml-tag",
+          worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+          tmux_window: "pr-690-e2e",
+        })),
+      restoreWorktree: vi.fn(async () => ({
+        branch: "gh-353-env-yaml-tag",
+        worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+      })),
+    });
+
+    await resumeWorkspace(
+      {
+        name: "pr-690-e2e",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.restoreWorktree).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      workspace_name: "gh-353-env-yaml-tag",
+      branch: "gh-353-env-yaml-tag",
+    });
+  });
+
+  it("syncs a PR workspace before resuming when requested", async () => {
+    const config = makeConfig();
+    const warnings: string[] = [];
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          name: "pr-42",
+          source_kind: "pr",
+          source_number: 42,
+          branch: "feature/example",
+          worktree_name: "pr-42",
+          worktree_path: "/tmp/worktrees/pr-42",
+          tmux_window: "pr-42",
+        }),
+      ),
+      restoreWorktree: vi.fn(async () => ({
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/pr-42",
+      })),
+      listWorktreesForBranch: vi.fn(async () => [
+        {
+          branch: "feature/example",
+          worktree_path: "/tmp/worktrees/pr-42",
+        },
+        {
+          branch: "feature/example",
+          worktree_path: "/tmp/worktrees/gh-353-env-yaml-tag",
+        },
+      ]),
+    });
+
+    await resumeWorkspace(
+      {
+        name: "pr-42",
+        sync: true,
+      },
+      config,
+      {
+        ...dependencies,
+        reportWarning: (warning) => warnings.push(warning),
+      },
+    );
+
+    expect(dependencies.isWorktreeDirty).toHaveBeenCalledWith(
+      "/tmp/worktrees/pr-42",
+    );
+    expect(dependencies.readPullRequest).toHaveBeenCalledWith({
+      repo: "kong/kongctl",
+      pr_number: 42,
+    });
+    expect(dependencies.fetchGitRef).toHaveBeenCalledWith({
+      repo: config.repos["kong/kongctl"],
+      remote: "origin",
+      fallback_remote: "https://github.com/kong/kongctl.git",
+      source_ref: "refs/pull/42/head",
+      destination_ref: "refs/pitch/pr/42/head",
+    });
+    expect(dependencies.fastForwardWorktree).toHaveBeenCalledWith({
+      worktree_path: "/tmp/worktrees/pr-42",
+      target_ref: "refs/pitch/pr/42/head",
+    });
+    expect(warnings).toEqual([
+      "Syncing feature/example for pr-42 will also move the branch ref used by other worktrees: /tmp/worktrees/gh-353-env-yaml-tag.",
+    ]);
+  });
+
+  it("fails sync when the worktree is dirty", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          name: "pr-42",
+          source_kind: "pr",
+          source_number: 42,
+          branch: "feature/example",
+          worktree_name: "pr-42",
+          worktree_path: "/tmp/worktrees/pr-42",
+          tmux_window: "pr-42",
+        }),
+      ),
+      restoreWorktree: vi.fn(async () => ({
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/pr-42",
+      })),
+      isWorktreeDirty: vi.fn(async () => true),
+    });
+
+    await expect(
+      resumeWorkspace(
+        {
+          name: "pr-42",
+          sync: true,
+        },
+        config,
+        dependencies,
+      ),
+    ).rejects.toThrow(
+      "Cannot sync pr-42: worktree /tmp/worktrees/pr-42 contains modified or untracked files.",
+    );
+    expect(dependencies.fetchGitRef).not.toHaveBeenCalled();
+    expect(dependencies.buildAgentResumeCommand).not.toHaveBeenCalled();
+  });
+
+  it("fails sync when a compatible agent pane is already running", async () => {
+    const config = makeConfig();
+    const dependencies = makeDependencies({
+      readWorkspaceRecord: vi.fn(async () =>
+        makeWorkspaceRecord({
+          name: "pr-42",
+          source_kind: "pr",
+          source_number: 42,
+          branch: "feature/example",
+          worktree_name: "pr-42",
+          worktree_path: "/tmp/worktrees/pr-42",
+          tmux_window: "pr-42",
+          agent_sessions: [],
+        }),
+      ),
+      restoreWorktree: vi.fn(async () => ({
+        branch: "feature/example",
+        worktree_path: "/tmp/worktrees/pr-42",
+      })),
+      getTmuxWindowPaneInfo: vi.fn(
+        async () =>
+          ({
+            pane_id: "%1",
+            current_command: "claude",
+            current_path: "/tmp/worktrees/pr-42",
+          }) satisfies TmuxPaneInfo,
+      ),
+    });
+
+    await expect(
+      resumeWorkspace(
+        {
+          name: "pr-42",
+          sync: true,
+        },
+        config,
+        dependencies,
+      ),
+    ).rejects.toThrow(
+      "Cannot sync pr-42 while a compatible agent pane is already running; use normal git commands inside the workspace instead.",
+    );
+    expect(dependencies.isWorktreeDirty).not.toHaveBeenCalled();
+  });
+
   it("launches fresh when there is no resumable session id", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({
@@ -385,7 +585,7 @@ describe("resume workspace", () => {
       workspace_name: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
       host_worktree_path: "/tmp/worktrees/gh-42-fix-bug",
-      initial_prompt: "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
+      initial_prompt: undefined,
     });
     expect(workspace.agent_sessions.at(-1)).toEqual({
       id: "claude-session-2",
@@ -462,7 +662,8 @@ describe("resume workspace", () => {
         pane_process_name: "ssh",
         pane_reuse_command:
           "env CODEX_HOME=~/.codex codex --cd /srv/pitch/workspaces/gh-42-fix-bug",
-        host_marker_path: "/tmp/worktrees/gh-42-fix-bug/.pitch/vm-agent-active",
+        host_marker_path:
+          "/tmp/worktrees/.pitch-state/gh-42-fix-bug/vm-agent-active",
         warnings: [],
       }) satisfies BuiltAgentCommand),
       getTmuxWindowPaneInfo: vi.fn(
@@ -561,6 +762,7 @@ describe("resume workspace", () => {
       agent: "codex",
       repo: "kong/kongctl",
       environment: undefined,
+      workspace_name: "gh-42-fix-bug",
       opencode_config_path: undefined,
       session_id: "codex-session-1",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
@@ -643,6 +845,7 @@ describe("resume workspace", () => {
       agent: "codex",
       repo: "kong/kongctl",
       environment: undefined,
+      workspace_name: "gh-42-fix-bug",
       opencode_config_path: undefined,
       session_id: "codex-session-new",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
@@ -725,7 +928,7 @@ describe("resume workspace", () => {
       workspace_name: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
       host_worktree_path: "/tmp/worktrees/gh-42-fix-bug",
-      initial_prompt: "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
+      initial_prompt: undefined,
     });
     expect(workspace.agent_sessions).toEqual([
       {
@@ -802,7 +1005,7 @@ describe("resume workspace", () => {
       workspace_name: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
       host_worktree_path: "/tmp/worktrees/gh-42-fix-bug",
-      initial_prompt: "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
+      initial_prompt: undefined,
     });
     expect(dependencies.runGitHubLifecycle).toHaveBeenCalledWith({
       repo: "kong/kongctl",
@@ -882,6 +1085,43 @@ describe("resume workspace", () => {
     expect(dependencies.getTmuxWindowPane).not.toHaveBeenCalled();
   });
 
+  it("runs configured pane commands when resume recreates the tmux layout", async () => {
+    const config = makeConfig();
+    config.repos["kong/kongctl"].pane_commands = {
+      top_right: "nvim .",
+      bottom_right: "make build",
+    };
+    const dependencies = makeDependencies({
+      tmuxWindowExists: vi
+        .fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false),
+    });
+
+    await resumeWorkspace(
+      {
+        name: "gh-42-fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(1, {
+      pane_id: "%1",
+      command:
+        "CLAUDE_CONFIG_DIR=~/.claude command -- 'claude' '--resume' " +
+        "'claude-session-1'",
+    });
+    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(2, {
+      pane_id: "%2",
+      command: "nvim .",
+    });
+    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(3, {
+      pane_id: "%3",
+      command: "make build",
+    });
+  });
+
   it("starts fresh when overriding to a different agent", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies();
@@ -905,7 +1145,7 @@ describe("resume workspace", () => {
       workspace_name: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
       host_worktree_path: "/tmp/worktrees/gh-42-fix-bug",
-      initial_prompt: "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
+      initial_prompt: undefined,
     });
     expect(dependencies.findCodexSessionForWorkspace).not.toHaveBeenCalled();
     expect(dependencies.runGitHubLifecycle).toHaveBeenCalledWith({
@@ -938,7 +1178,7 @@ describe("resume workspace", () => {
       workspace_name: "gh-42-fix-bug",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
       host_worktree_path: "/tmp/worktrees/gh-42-fix-bug",
-      initial_prompt: "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
+      initial_prompt: undefined,
     });
     expect(dependencies.runGitHubLifecycle).toHaveBeenCalledWith({
       repo: "kong/kongctl",
@@ -979,7 +1219,7 @@ describe("resume workspace", () => {
     ).rejects.toThrow("Workspace not found: gh-404-missing");
   });
 
-  it("errors when the workspace is not active", async () => {
+  it("reopens a closed workspace on resume", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({
       readWorkspaceRecord: vi.fn(async () =>
@@ -989,15 +1229,43 @@ describe("resume workspace", () => {
       ),
     });
 
-    await expect(
-      resumeWorkspace(
-        {
-          name: "gh-42-fix-bug",
-        },
-        config,
-        dependencies,
-      ),
-    ).rejects.toThrow("Workspace is not active: gh-42-fix-bug");
+    const workspace = await resumeWorkspace(
+      {
+        name: "gh-42-fix-bug",
+      },
+      config,
+      dependencies,
+    );
+
+    expect(dependencies.buildAgentResumeCommand).toHaveBeenCalledWith({
+      config,
+      agent: "claude-enterprise",
+      repo: "kong/kongctl",
+      environment: undefined,
+      workspace_name: "gh-42-fix-bug",
+      opencode_config_path: undefined,
+      session_id: "claude-session-1",
+      worktree_path: "/tmp/worktrees/gh-42-fix-bug",
+      host_worktree_path: "/tmp/worktrees/gh-42-fix-bug",
+    });
+    expect(workspace).toEqual(
+      makeWorkspaceRecord({
+        status: "active",
+        agent_sessions: [
+          {
+            id: "claude-session-1",
+            started_at: "2026-03-22T20:30:00.000Z",
+            status: "active",
+          },
+          {
+            id: "claude-session-1",
+            started_at: "2026-03-23T04:00:00.000Z",
+            status: "active",
+          },
+        ],
+        updated_at: "2026-03-23T04:00:00.000Z",
+      }),
+    );
   });
 
   it("errors when the tmux window is missing", async () => {
@@ -1079,6 +1347,7 @@ describe("resume workspace", () => {
       agent: "opencode",
       repo: "kong/kongctl",
       environment: undefined,
+      workspace_name: "gh-42-fix-bug",
       opencode_config_path: undefined,
       session_id: "ses_123",
       worktree_path: "/tmp/worktrees/gh-42-fix-bug",
@@ -1207,7 +1476,7 @@ describe("resume workspace", () => {
     );
   });
 
-  it("sends a deferred bootstrap prompt for a fresh attach-mode OpenCode launch", async () => {
+  it("does not send a deferred bootstrap prompt for a fresh attach-mode OpenCode launch", async () => {
     const config = makeConfig();
     const dependencies = makeDependencies({
       readWorkspaceRecord: vi.fn(async () =>
@@ -1246,8 +1515,6 @@ describe("resume workspace", () => {
           OPENCODE_SERVER_PASSWORD: "secret",
         },
         pane_process_name: "opencode",
-        post_launch_prompt:
-          "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
         warnings: [],
       }) satisfies BuiltAgentCommand),
     });
@@ -1266,15 +1533,9 @@ describe("resume workspace", () => {
         "OPENCODE_SERVER_PASSWORD='secret' command -- 'opencode' " +
         "'attach' 'http://localhost:4096' '--dir' '/tmp/worktrees/gh-42-fix-bug'",
     });
-    expect(dependencies.getTmuxPaneInfo).toHaveBeenCalledWith({
-      pane_id: "%1",
-    });
-    expect(dependencies.sleep).toHaveBeenCalledWith(10000);
-    expect(dependencies.sendKeysToPane).toHaveBeenNthCalledWith(2, {
-      pane_id: "%1",
-      command: "Read issue #42 in kong/kongctl on gh-42-fix-bug and wait.",
-      literal: true,
-    });
+    expect(dependencies.getTmuxPaneInfo).not.toHaveBeenCalled();
+    expect(dependencies.sleep).not.toHaveBeenCalled();
+    expect(dependencies.sendKeysToPane).toHaveBeenCalledTimes(1);
   });
 
   it("wraps tmux pane lookup failures", async () => {

--- a/src/__tests__/workspace-query.test.ts
+++ b/src/__tests__/workspace-query.test.ts
@@ -10,8 +10,9 @@ import type { WorkspaceRecord } from "../workspace-state.js";
 function makeWorkspaceRecord(
   overrides: Partial<WorkspaceRecord> = {},
 ): WorkspaceRecord {
-  return {
+  const workspace: WorkspaceRecord = {
     name: "gh-42-fix-bug",
+    worktree_name: "gh-42-fix-bug",
     repo: "kong/kongctl",
     source_kind: "issue",
     source_number: 42,
@@ -38,6 +39,12 @@ function makeWorkspaceRecord(
     updated_at: "2026-03-22T20:30:00.000Z",
     ...overrides,
   };
+
+  if (overrides.worktree_name === undefined) {
+    workspace.worktree_name = workspace.name;
+  }
+
+  return workspace;
 }
 
 function makeDependencies(

--- a/src/agent-launcher.ts
+++ b/src/agent-launcher.ts
@@ -45,6 +45,7 @@ export interface BuildResumeCommandInput {
   repo?: string;
   opencode_config_path?: string;
   environment?: string;
+  workspace_name: string;
   session_id: string;
   worktree_path?: string;
   host_worktree_path?: string;
@@ -320,6 +321,7 @@ function wrapExecutionEnvironmentCommand(
   environment: ResolvedExecutionEnvironment,
   runtimeCommand: RuntimeWrappedCommand,
   agentEnv: Record<string, string>,
+  workspaceName: string,
   workspacePaths: ResolvedWorkspacePaths | null,
   runBootstrap: boolean,
 ): {
@@ -345,6 +347,7 @@ function wrapExecutionEnvironmentCommand(
 
   const vmCommand = buildVmSshCommand({
     environment: environment.config as VmSshExecutionEnvironmentConfig,
+    workspace_name: workspaceName,
     workspace_paths: workspacePaths,
     agent_command: runtimeCommand.command,
     agent_env: agentEnv,
@@ -392,6 +395,7 @@ function buildClaudeStartCommand(
     environment,
     runtimeCommand,
     agentEnv,
+    input.workspace_name,
     workspacePaths,
     true,
   );
@@ -429,6 +433,7 @@ function buildClaudeResumeCommand(
     environment,
     runtimeCommand,
     agentEnv,
+    input.workspace_name,
     workspacePaths,
     false,
   );
@@ -479,6 +484,7 @@ function buildCodexStartCommand(
     environment,
     runtimeCommand,
     agentEnv,
+    input.workspace_name,
     workspacePaths,
     true,
   );
@@ -515,6 +521,7 @@ function buildCodexResumeCommand(
     environment,
     runtimeCommand,
     agentEnv,
+    input.workspace_name,
     workspacePaths,
     false,
   );
@@ -586,6 +593,7 @@ function buildOpencodeStartCommand(
     environment,
     runtimeCommand,
     agentEnv,
+    input.workspace_name,
     workspacePaths,
     true,
   );
@@ -665,6 +673,7 @@ function buildOpencodeResumeCommand(
     environment,
     runtimeCommand,
     agentEnv,
+    input.workspace_name,
     workspacePaths,
     false,
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,10 @@
 import { stdout as defaultStdout, stderr as defaultStderr } from "node:process";
-import { closeWorkspace, type CloseWorkspaceInput } from "./close-workspace.js";
+import {
+  closeWorkspace,
+  deleteWorkspace,
+  type CloseWorkspaceInput,
+  type DeleteWorkspaceInput,
+} from "./close-workspace.js";
 import { loadConfig } from "./config.js";
 import { createWorkspace, type CreateWorkspaceInput } from "./create-workspace.js";
 import { resumeWorkspace, type ResumeWorkspaceInput } from "./resume-workspace.js";
@@ -42,6 +47,7 @@ export interface CliDependencies {
   getWorkspace: typeof getWorkspace;
   resumeWorkspace: typeof resumeWorkspace;
   closeWorkspace: typeof closeWorkspace;
+  deleteWorkspace: typeof deleteWorkspace;
   stdout: { write(chunk: string): void };
   stderr: { write(chunk: string): void };
 }
@@ -53,6 +59,7 @@ const defaultDependencies: CliDependencies = {
   getWorkspace,
   resumeWorkspace,
   closeWorkspace,
+  deleteWorkspace,
   stdout: defaultStdout,
   stderr: defaultStderr,
 };
@@ -61,7 +68,8 @@ const BOOLEAN_FLAGS = new Set([
   "help",
   "json",
   "skip-prompt",
-  "keep-worktree",
+  "force",
+  "sync",
 ]);
 
 const STRING_FLAGS = new Set([
@@ -88,6 +96,13 @@ function setFlag(
   value: FlagValue,
 ): void {
   flags.set(normalizeFlagName(flagName), value);
+}
+
+function hasImplicitCreateFlags(flags: Map<string, FlagValue>): boolean {
+  const hasIssue = typeof flags.get("issue") === "string";
+  const hasPr = typeof flags.get("pr") === "string";
+
+  return hasIssue !== hasPr;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -152,6 +167,14 @@ function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (positionals.length === 0) {
+    if (hasImplicitCreateFlags(flags)) {
+      return {
+        verb: "create",
+        flags,
+        positionals,
+      };
+    }
+
     return {
       verb: "help",
       flags,
@@ -164,6 +187,14 @@ function parseArgs(argv: string[]): ParsedArgs {
   if (maybeAlias === "workspace") {
     remaining.shift();
     if (remaining.length === 0) {
+      if (hasImplicitCreateFlags(flags)) {
+        return {
+          verb: "create",
+          flags,
+          positionals: [],
+        };
+      }
+
       return {
         verb: "help",
         flags,
@@ -290,7 +321,7 @@ function buildCreateInput(flags: Map<string, FlagValue>): CreateWorkspaceInput {
     repo: readStringFlag(flags, "repo"),
     issue: readNumberFlag(flags, "issue"),
     pr: readNumberFlag(flags, "pr"),
-    slug: readStringFlag(flags, "slug") ?? "",
+    slug: readStringFlag(flags, "slug"),
     base_branch: readStringFlag(flags, "base-branch"),
     agent: readStringFlag(flags, "agent"),
     environment: readStringFlag(flags, "environment"),
@@ -330,6 +361,7 @@ function buildResumeInput(
     name: resolveWorkspaceName(flags, positionals),
     agent: readStringFlag(flags, "agent"),
     environment: readStringFlag(flags, "environment"),
+    sync: readBooleanFlag(flags, "sync"),
   };
 }
 
@@ -337,11 +369,18 @@ function buildCloseInput(
   flags: Map<string, FlagValue>,
   positionals: string[],
 ): CloseWorkspaceInput {
-  const keepWorktree = readBooleanFlag(flags, "keep-worktree");
   return {
     name: resolveWorkspaceName(flags, positionals),
-    cleanup_worktree:
-      keepWorktree === true ? false : undefined,
+  };
+}
+
+function buildDeleteInput(
+  flags: Map<string, FlagValue>,
+  positionals: string[],
+): DeleteWorkspaceInput {
+  return {
+    name: resolveWorkspaceName(flags, positionals),
+    force: readBooleanFlag(flags, "force"),
   };
 }
 
@@ -399,12 +438,12 @@ function formatWorkspaceList(workspaces: WorkspaceSummary[]): string {
 function buildHelpText(): string {
   return [
     "Usage:",
-    "  pitch create (--issue N | --pr N) --slug SLUG [options]",
+    "  pitch [create] (--issue N | --pr N) [--slug SLUG] [options]",
     "  pitch list [--repo REPO] [--status active|closed|all]",
     "  pitch get <name>",
-    "  pitch resume <name> [--agent AGENT] [--environment ENV]",
-    "  pitch close <name> [--keep-worktree]",
-    "  pitch delete <name> [--keep-worktree]",
+    "  pitch resume <name> [--agent AGENT] [--environment ENV] [--sync]",
+    "  pitch close <name>",
+    "  pitch delete <name> [--force]",
     "  pitch completion zsh",
     "  pitch workspace <command> ...",
     "",
@@ -416,16 +455,18 @@ function buildHelpText(): string {
     "  --base-branch BRANCH",
     "  --agent AGENT",
     "  --environment ENV",
+    "  --sync",
     "  --runtime native|docker",
     "  --model MODEL",
     "  --skip-prompt",
+    "  --force",
     "  --status active|closed|all",
     "  --name NAME",
-    "  --keep-worktree",
     "  --json",
     "  --help",
     "",
-    "The `workspace` noun is accepted as an alias for compatibility.",
+    "If --issue or --pr is provided without an explicit command, create is",
+    "implied.",
   ].join("\n");
 }
 
@@ -466,7 +507,7 @@ function buildZshCompletionScript(): string {
     "        '--repo[GitHub org/repo]:repo:' \\",
     "        '--issue[Issue number]:issue:' \\",
     "        '--pr[Pull request number]:pr:' \\",
-    "        '--slug[Workspace slug]:slug:' \\",
+    "        '--slug[Optional workspace slug suffix]:slug:' \\",
     "        '--base-branch[Base branch]:branch:' \\",
     "        '--agent[Configured agent]:agent:' \\",
     "        '--environment[Execution environment]:environment:' \\",
@@ -492,20 +533,29 @@ function buildZshCompletionScript(): string {
     "        '1:workspace:_pitch_workspaces'",
     "      ;;",
     "    resume)",
-    "      _pitch_complete_workspace_target \"$command_index\" && return",
-    "      _arguments -s -S \\",
+      "      _pitch_complete_workspace_target \"$command_index\" && return",
+      "      _arguments -s -S \\",
     "        '--name[Workspace name]:workspace:_pitch_workspaces' \\",
     "        '--agent[Configured agent]:agent:' \\",
     "        '--environment[Execution environment]:environment:' \\",
+    "        '--sync[Fast-forward PR workspaces to latest upstream head before resuming]' \\",
     "        '--json[Emit JSON]' \\",
     "        '--help[Show help]' \\",
     "        '1:workspace:_pitch_workspaces'",
     "      ;;",
-    "    close|delete)",
+    "    close)",
+      "      _pitch_complete_workspace_target \"$command_index\" && return",
+      "      _arguments -s -S \\",
+    "        '--name[Workspace name]:workspace:_pitch_workspaces' \\",
+    "        '--json[Emit JSON]' \\",
+    "        '--help[Show help]' \\",
+    "        '1:workspace:_pitch_workspaces'",
+    "      ;;",
+    "    delete)",
     "      _pitch_complete_workspace_target \"$command_index\" && return",
     "      _arguments -s -S \\",
     "        '--name[Workspace name]:workspace:_pitch_workspaces' \\",
-    "        '--keep-worktree[Keep the worktree after closing]' \\",
+    "        '--force[Delete even if the worktree has local changes]' \\",
     "        '--json[Emit JSON]' \\",
     "        '--help[Show help]' \\",
     "        '1:workspace:_pitch_workspaces'",
@@ -517,6 +567,11 @@ function buildZshCompletionScript(): string {
     "}",
     "",
     "_pitch() {",
+    "  if [[ \"${words[2]}\" == --* ]]; then",
+    "    _pitch_dispatch \"create\" 1",
+    "    return",
+    "  fi",
+    "",
     "  if (( CURRENT == 2 )); then",
     "    _values 'pitch command' \\",
     "      'create[Create a workspace]' \\",
@@ -531,6 +586,11 @@ function buildZshCompletionScript(): string {
     "  fi",
     "",
     "  if [[ \"${words[2]}\" == \"workspace\" ]]; then",
+    "    if [[ \"${words[3]}\" == --* ]]; then",
+    "      _pitch_dispatch \"create\" 2",
+    "      return",
+    "    fi",
+    "",
     "    if (( CURRENT == 3 )); then",
     "      _values 'pitch workspace command' \\",
     "        'create[Create a workspace]' \\",
@@ -617,13 +677,23 @@ async function executeCommand(
         warnings,
       };
     }
-    case "close":
+    case "close": {
+      const config = await dependencies.loadConfig();
+      return {
+        command: parsed.verb,
+        result: await dependencies.closeWorkspace(
+          buildCloseInput(parsed.flags, parsed.positionals),
+          config,
+        ),
+        warnings: [],
+      };
+    }
     case "delete": {
       const config = await dependencies.loadConfig();
       return {
-        command: "close",
-        result: await dependencies.closeWorkspace(
-          buildCloseInput(parsed.flags, parsed.positionals),
+        command: parsed.verb,
+        result: await dependencies.deleteWorkspace(
+          buildDeleteInput(parsed.flags, parsed.positionals),
           config,
         ),
         warnings: [],

--- a/src/close-workspace.ts
+++ b/src/close-workspace.ts
@@ -10,7 +10,11 @@ import {
   resolveExecutionEnvironment,
   resolveWorkspacePaths,
 } from "./execution-environment.js";
-import { GitWorktreeError, removeWorktree } from "./git.js";
+import {
+  GitWorktreeError,
+  isWorktreeDirty,
+  removeWorktree,
+} from "./git.js";
 import {
   getTmuxWindowPaneInfo,
   killTmuxWindow,
@@ -18,6 +22,8 @@ import {
 } from "./tmux.js";
 import {
   deleteWorkspaceRecord,
+  getWorkspaceWorktreeName,
+  listWorkspaceRecords,
   readWorkspaceRecord,
   WorkspaceRecordSchema,
   writeWorkspaceRecord,
@@ -27,35 +33,47 @@ import { deleteOpencodeConfig } from "./opencode-config.js";
 
 export const CloseWorkspaceInputSchema = z.object({
   name: z.string().trim().min(1),
-  cleanup_worktree: z.boolean().optional(),
+}).strict();
+
+export const DeleteWorkspaceInputSchema = z.object({
+  name: z.string().trim().min(1),
+  force: z.boolean().optional(),
 }).strict();
 
 export type CloseWorkspaceInput = z.infer<typeof CloseWorkspaceInputSchema>;
+export type DeleteWorkspaceInput = z.infer<typeof DeleteWorkspaceInputSchema>;
 
-export interface CloseWorkspaceDependencies {
+export interface WorkspaceLifecycleDependencies {
   deleteOpencodeConfig: typeof deleteOpencodeConfig;
   deleteWorkspaceRecord: typeof deleteWorkspaceRecord;
   getTmuxWindowPaneInfo: typeof getTmuxWindowPaneInfo;
+  isWorktreeDirty: typeof isWorktreeDirty;
   killTmuxWindow: typeof killTmuxWindow;
+  listWorkspaceRecords: typeof listWorkspaceRecords;
   readWorkspaceRecord: typeof readWorkspaceRecord;
+  removeCodexTrustedPath: typeof removeCodexTrustedPath;
+  removeWorktree: typeof removeWorktree;
   sendKeysToPane: typeof sendKeysToPane;
   writeWorkspaceRecord: typeof writeWorkspaceRecord;
-  removeWorktree: typeof removeWorktree;
-  removeCodexTrustedPath: typeof removeCodexTrustedPath;
   sleep: (milliseconds: number) => Promise<void>;
   now: () => Date;
 }
 
-const defaultDependencies: CloseWorkspaceDependencies = {
+export type CloseWorkspaceDependencies = WorkspaceLifecycleDependencies;
+export type DeleteWorkspaceDependencies = WorkspaceLifecycleDependencies;
+
+const defaultDependencies: WorkspaceLifecycleDependencies = {
   deleteOpencodeConfig,
   deleteWorkspaceRecord,
   getTmuxWindowPaneInfo,
+  isWorktreeDirty,
   killTmuxWindow,
+  listWorkspaceRecords,
   readWorkspaceRecord,
+  removeCodexTrustedPath,
+  removeWorktree,
   sendKeysToPane,
   writeWorkspaceRecord,
-  removeWorktree,
-  removeCodexTrustedPath,
   sleep: async (milliseconds: number) => {
     await delay(milliseconds);
   },
@@ -66,6 +84,13 @@ export class CloseWorkspaceError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "CloseWorkspaceError";
+  }
+}
+
+export class DeleteWorkspaceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeleteWorkspaceError";
   }
 }
 
@@ -83,7 +108,7 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
-function validateInput(params: CloseWorkspaceInput): CloseWorkspaceInput {
+function validateCloseInput(params: CloseWorkspaceInput): CloseWorkspaceInput {
   const result = CloseWorkspaceInputSchema.safeParse(params);
   if (!result.success) {
     throw new CloseWorkspaceError(
@@ -94,10 +119,23 @@ function validateInput(params: CloseWorkspaceInput): CloseWorkspaceInput {
   return result.data;
 }
 
+function validateDeleteInput(
+  params: DeleteWorkspaceInput,
+): DeleteWorkspaceInput {
+  const result = DeleteWorkspaceInputSchema.safeParse(params);
+  if (!result.success) {
+    throw new DeleteWorkspaceError(
+      `Invalid delete_workspace input:\n${formatZodIssues(result.error)}`,
+    );
+  }
+
+  return result.data;
+}
+
 function resolveRepoConfig(config: PitchConfig, repoName: string): RepoConfig {
   const repoConfig = config.repos[repoName];
   if (repoConfig === undefined) {
-    throw new CloseWorkspaceError(`Repo is not configured: ${repoName}`);
+    throw new Error(`Repo is not configured: ${repoName}`);
   }
 
   return repoConfig;
@@ -116,6 +154,32 @@ function buildClosedWorkspaceRecord(
 
 function isMissingWorktreeError(error: unknown): boolean {
   return error instanceof GitWorktreeError && error.code === "WORKTREE_MISSING";
+}
+
+function sharesWorktree(
+  candidate: WorkspaceRecord,
+  workspace: WorkspaceRecord,
+): boolean {
+  return (
+    candidate.name !== workspace.name &&
+    candidate.repo === workspace.repo &&
+    (
+      getWorkspaceWorktreeName(candidate) ===
+        getWorkspaceWorktreeName(workspace) ||
+      candidate.worktree_path === workspace.worktree_path
+    )
+  );
+}
+
+async function hasSharedWorktreeReferences(
+  workspace: WorkspaceRecord,
+  dependencies: WorkspaceLifecycleDependencies,
+): Promise<boolean> {
+  const workspaces = await dependencies.listWorkspaceRecords({
+    repo: workspace.repo,
+    status: "all",
+  });
+  return workspaces.some((candidate) => sharesWorktree(candidate, workspace));
 }
 
 const SHELL_COMMANDS = new Set([
@@ -140,7 +204,7 @@ async function pathExists(path: string): Promise<boolean> {
 
 async function tryGracefulAgentShutdown(
   workspace: WorkspaceRecord,
-  dependencies: CloseWorkspaceDependencies,
+  dependencies: WorkspaceLifecycleDependencies,
 ): Promise<void> {
   let paneInfo;
 
@@ -168,7 +232,11 @@ async function tryGracefulAgentShutdown(
 
   if (
     workspace.environment_kind === "vm-ssh" &&
-    !(await pathExists(buildVmAgentHostMarkerPath(workspace.worktree_path)))
+    !(
+      await pathExists(
+        buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
+      )
+    )
   ) {
     return;
   }
@@ -194,7 +262,13 @@ async function tryGracefulAgentShutdown(
       });
 
       if (workspace.environment_kind === "vm-ssh") {
-        if (!(await pathExists(buildVmAgentHostMarkerPath(workspace.worktree_path)))) {
+        if (
+          !(
+            await pathExists(
+              buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
+            )
+          )
+        ) {
           return;
         }
       } else if (SHELL_COMMANDS.has(updatedPaneInfo.current_command)) {
@@ -206,156 +280,264 @@ async function tryGracefulAgentShutdown(
   }
 }
 
+async function closeActiveWorkspaceSession(
+  workspace: WorkspaceRecord,
+  dependencies: WorkspaceLifecycleDependencies,
+): Promise<void> {
+  if (workspace.status === "closed") {
+    return;
+  }
+
+  await tryGracefulAgentShutdown(workspace, dependencies);
+
+  try {
+    await dependencies.killTmuxWindow({
+      session_name: workspace.tmux_session,
+      window_name: workspace.tmux_window,
+    });
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to close tmux window for ${workspace.name}: ${formatError(error)}`,
+    );
+  }
+}
+
+async function maybeRemoveCodexTrustedPath(
+  workspace: WorkspaceRecord,
+  config: PitchConfig,
+  dependencies: WorkspaceLifecycleDependencies,
+): Promise<void> {
+  if (workspace.agent_type !== "codex") {
+    return;
+  }
+
+  try {
+    const environment =
+      workspace.environment_name !== null &&
+      workspace.environment_name !== undefined
+        ? resolveExecutionEnvironment(
+            config,
+            workspace.repo,
+            workspace.environment_name,
+          )
+        : { kind: workspace.environment_kind ?? "host" };
+    const workspacePaths = resolveWorkspacePaths(
+      environment,
+      getWorkspaceWorktreeName(workspace),
+      workspace.worktree_path,
+    );
+    workspacePaths.agent_worktree_path =
+      workspace.guest_worktree_path ?? workspacePaths.agent_worktree_path;
+    workspacePaths.guest_worktree_path =
+      workspace.guest_worktree_path ?? workspacePaths.guest_worktree_path;
+
+    await dependencies.removeCodexTrustedPath({
+      environment,
+      workspace_paths: workspacePaths,
+      codex_home: workspace.agent_env.CODEX_HOME,
+    });
+  } catch {
+    // best-effort cleanup only
+  }
+}
+
+async function readWorkspaceOrThrow(
+  name: string,
+  dependencies: WorkspaceLifecycleDependencies,
+  ErrorCtor: typeof CloseWorkspaceError | typeof DeleteWorkspaceError,
+): Promise<WorkspaceRecord> {
+  let workspace: WorkspaceRecord | null;
+  try {
+    workspace = await dependencies.readWorkspaceRecord(name);
+  } catch (error: unknown) {
+    throw new ErrorCtor(
+      `Failed to read workspace "${name}": ${formatError(error)}`,
+    );
+  }
+
+  if (workspace === null) {
+    throw new ErrorCtor(`Workspace not found: ${name}`);
+  }
+
+  return workspace;
+}
+
 export async function closeWorkspace(
   params: CloseWorkspaceInput,
   config: PitchConfig,
   dependencyOverrides: Partial<CloseWorkspaceDependencies> = {},
 ): Promise<WorkspaceRecord> {
-  const input = validateInput(params);
+  const input = validateCloseInput(params);
   const dependencies: CloseWorkspaceDependencies = {
     ...defaultDependencies,
     ...dependencyOverrides,
   };
 
-  let existingWorkspace: WorkspaceRecord | null;
+  const existingWorkspace = await readWorkspaceOrThrow(
+    input.name,
+    dependencies,
+    CloseWorkspaceError,
+  );
+
+  if (existingWorkspace.status === "closed") {
+    return existingWorkspace;
+  }
+
   try {
-    existingWorkspace = await dependencies.readWorkspaceRecord(input.name);
+    await closeActiveWorkspaceSession(existingWorkspace, dependencies);
+  } catch (error: unknown) {
+    throw new CloseWorkspaceError(formatError(error));
+  }
+
+  const closedWorkspace = buildClosedWorkspaceRecord(
+    existingWorkspace,
+    dependencies.now().toISOString(),
+  );
+
+  try {
+    return await dependencies.writeWorkspaceRecord(closedWorkspace);
   } catch (error: unknown) {
     throw new CloseWorkspaceError(
-      `Failed to read workspace "${input.name}": ${formatError(error)}`,
+      `Failed to update workspace state for ${input.name}: ${formatError(error)}`,
+    );
+  }
+}
+
+async function ensureWorktreeDeletable(
+  workspace: WorkspaceRecord,
+  force: boolean,
+  dependencies: WorkspaceLifecycleDependencies,
+): Promise<void> {
+  if (force) {
+    return;
+  }
+
+  let isDirty: boolean;
+  try {
+    isDirty = await dependencies.isWorktreeDirty(workspace.worktree_path);
+  } catch (error: unknown) {
+    throw new DeleteWorkspaceError(
+      `Failed to inspect worktree for ${workspace.name}: ${formatError(error)}`,
     );
   }
 
-  if (existingWorkspace === null) {
-    throw new CloseWorkspaceError(`Workspace not found: ${input.name}`);
+  if (isDirty) {
+    throw new DeleteWorkspaceError(
+      `Worktree ${workspace.worktree_path} contains modified or untracked files; rerun with --force to delete it.`,
+    );
+  }
+}
+
+async function deleteWorkspaceState(
+  name: string,
+  dependencies: WorkspaceLifecycleDependencies,
+): Promise<void> {
+  try {
+    await dependencies.deleteWorkspaceRecord(name);
+  } catch (error: unknown) {
+    throw new DeleteWorkspaceError(
+      `Failed to delete workspace state for ${name}: ${formatError(error)}`,
+    );
+  }
+}
+
+export async function deleteWorkspace(
+  params: DeleteWorkspaceInput,
+  config: PitchConfig,
+  dependencyOverrides: Partial<DeleteWorkspaceDependencies> = {},
+): Promise<WorkspaceRecord> {
+  const input = validateDeleteInput(params);
+  const dependencies: DeleteWorkspaceDependencies = {
+    ...defaultDependencies,
+    ...dependencyOverrides,
+  };
+
+  const existingWorkspace = await readWorkspaceOrThrow(
+    input.name,
+    dependencies,
+    DeleteWorkspaceError,
+  );
+  const closedWorkspace =
+    existingWorkspace.status === "closed"
+      ? existingWorkspace
+      : buildClosedWorkspaceRecord(
+          existingWorkspace,
+          dependencies.now().toISOString(),
+        );
+
+  let hasSharedReferences: boolean;
+  try {
+    hasSharedReferences = await hasSharedWorktreeReferences(
+      existingWorkspace,
+      dependencies,
+    );
+  } catch (error: unknown) {
+    throw new DeleteWorkspaceError(
+      `Failed to inspect shared worktree usage for ${input.name}: ${formatError(error)}`,
+    );
   }
 
-  const isAlreadyClosed = existingWorkspace.status === "closed";
-  const closedAt = dependencies.now().toISOString();
-  const closedWorkspace = isAlreadyClosed
-    ? existingWorkspace
-    : buildClosedWorkspaceRecord(existingWorkspace, closedAt);
-  const shouldCleanupWorktree = input.cleanup_worktree ?? true;
-  const repoConfig: RepoConfig | undefined = shouldCleanupWorktree
-    ? resolveRepoConfig(config, existingWorkspace.repo)
-    : undefined;
+  if (!hasSharedReferences) {
+    await ensureWorktreeDeletable(
+      existingWorkspace,
+      input.force === true,
+      dependencies,
+    );
+  }
 
-  if (!isAlreadyClosed) {
-    await tryGracefulAgentShutdown(existingWorkspace, dependencies);
+  if (existingWorkspace.status !== "closed") {
+    try {
+      await closeActiveWorkspaceSession(existingWorkspace, dependencies);
+    } catch (error: unknown) {
+      throw new DeleteWorkspaceError(formatError(error));
+    }
 
     try {
-      await dependencies.killTmuxWindow({
-        session_name: existingWorkspace.tmux_session,
-        window_name: existingWorkspace.tmux_window,
-      });
+      await dependencies.writeWorkspaceRecord(closedWorkspace);
     } catch (error: unknown) {
-      throw new CloseWorkspaceError(
-        `Failed to close tmux window for ${input.name}: ${formatError(error)}`,
+      throw new DeleteWorkspaceError(
+        `Failed to update workspace state for ${input.name}: ${formatError(error)}`,
       );
     }
   }
 
   try {
     await dependencies.deleteOpencodeConfig(existingWorkspace.name);
-  } catch {}
-
-  if (shouldCleanupWorktree && existingWorkspace.agent_type === "codex") {
-    try {
-      const environment = existingWorkspace.environment_name !== null &&
-          existingWorkspace.environment_name !== undefined
-        ? resolveExecutionEnvironment(
-            config,
-            existingWorkspace.repo,
-            existingWorkspace.environment_name,
-          )
-        : { kind: existingWorkspace.environment_kind ?? "host" };
-      const workspacePaths = resolveWorkspacePaths(
-        environment,
-        existingWorkspace.name,
-        existingWorkspace.worktree_path,
-      );
-      workspacePaths.agent_worktree_path =
-        existingWorkspace.guest_worktree_path ?? workspacePaths.agent_worktree_path;
-      workspacePaths.guest_worktree_path =
-        existingWorkspace.guest_worktree_path ?? workspacePaths.guest_worktree_path;
-
-      await dependencies.removeCodexTrustedPath({
-        environment,
-        workspace_paths: workspacePaths,
-        codex_home: existingWorkspace.agent_env.CODEX_HOME,
-      });
-    } catch {
-      // best-effort cleanup only
-    }
+  } catch {
+    // best-effort cleanup only
   }
 
-  if (!shouldCleanupWorktree) {
-    try {
-      return await dependencies.writeWorkspaceRecord(closedWorkspace);
-    } catch (error: unknown) {
-      throw new CloseWorkspaceError(
-        `Failed to update workspace state for ${input.name}: ${formatError(error)}`,
-      );
-    }
+  if (hasSharedReferences) {
+    await deleteWorkspaceState(existingWorkspace.name, dependencies);
+    return closedWorkspace;
   }
 
-  if (repoConfig === undefined) {
-    throw new CloseWorkspaceError(
-      `Internal error: missing repo config for ${existingWorkspace.repo}`,
-    );
+  let repoConfig: RepoConfig;
+  try {
+    repoConfig = resolveRepoConfig(config, existingWorkspace.repo);
+  } catch (error: unknown) {
+    throw new DeleteWorkspaceError(formatError(error));
   }
+
+  await maybeRemoveCodexTrustedPath(existingWorkspace, config, dependencies);
 
   try {
     await dependencies.removeWorktree({
       repo: repoConfig,
-      workspace_name: existingWorkspace.name,
+      workspace_name: getWorkspaceWorktreeName(existingWorkspace),
+      worktree_path: existingWorkspace.worktree_path,
+      ...(input.force === true ? { force: true } : {}),
     });
   } catch (error: unknown) {
     if (!isMissingWorktreeError(error)) {
-      if (isAlreadyClosed) {
-        throw new CloseWorkspaceError(
-          `Failed to clean up worktree for ${input.name}: ${formatError(error)}`,
-        );
-      }
-
-      try {
-        await dependencies.writeWorkspaceRecord(closedWorkspace);
-      } catch (fallbackError: unknown) {
-        throw new CloseWorkspaceError(
-          `Failed to clean up worktree for ${input.name}: ${formatError(error)}\n` +
-            `Fallback state write also failed: ${formatError(fallbackError)}`,
-        );
-      }
-
-      throw new CloseWorkspaceError(
-        `Failed to clean up worktree for ${input.name}: ${formatError(error)}`,
+      throw new DeleteWorkspaceError(
+        `Failed to remove worktree for ${input.name}: ${formatError(error)}`,
       );
     }
   }
 
-  try {
-    await dependencies.deleteWorkspaceRecord(existingWorkspace.name);
-    return closedWorkspace;
-  } catch (error: unknown) {
-    if (isAlreadyClosed) {
-      throw new CloseWorkspaceError(
-        `Failed to delete workspace state for ${input.name}: ${formatError(error)}`,
-      );
-    }
-
-    try {
-      await dependencies.writeWorkspaceRecord(closedWorkspace);
-    } catch (fallbackError: unknown) {
-      throw new CloseWorkspaceError(
-        `Failed to delete workspace state for ${input.name}: ${formatError(error)}\n` +
-          `Fallback state write also failed: ${formatError(fallbackError)}`,
-      );
-    }
-
-    throw new CloseWorkspaceError(
-      `Failed to delete workspace state for ${input.name}: ${formatError(error)}`,
-    );
-  }
+  await deleteWorkspaceState(existingWorkspace.name, dependencies);
+  return closedWorkspace;
 }
 
 export function registerCloseWorkspaceTool(
@@ -367,12 +549,35 @@ export function registerCloseWorkspaceTool(
     "close_workspace",
     {
       description:
-        "Close a workspace by tearing down its tmux window and, by default, removing its git worktree and state file.",
+        "Close a workspace by tearing down its tmux window and marking it closed. Worktree cleanup is handled by delete_workspace.",
       inputSchema: CloseWorkspaceInputSchema,
       outputSchema: WorkspaceRecordSchema,
     },
     async (args) => {
       const workspace = await closeWorkspace(args, config, dependencies);
+      return {
+        content: [{ type: "text", text: JSON.stringify(workspace) }],
+        structuredContent: workspace,
+      };
+    },
+  );
+}
+
+export function registerDeleteWorkspaceTool(
+  server: McpServer,
+  config: PitchConfig,
+  dependencies: Partial<DeleteWorkspaceDependencies> = {},
+): void {
+  server.registerTool(
+    "delete_workspace",
+    {
+      description:
+        "Delete a workspace by removing its state file and, when applicable, its git worktree. Refuses dirty worktrees unless force is set.",
+      inputSchema: DeleteWorkspaceInputSchema,
+      outputSchema: WorkspaceRecordSchema,
+    },
+    async (args) => {
+      const workspace = await deleteWorkspace(args, config, dependencies);
       return {
         content: [{ type: "text", text: JSON.stringify(workspace) }],
         structuredContent: workspace,

--- a/src/close-workspace.ts
+++ b/src/close-workspace.ts
@@ -1,12 +1,11 @@
 import { setTimeout as delay } from "node:timers/promises";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { access } from "node:fs/promises";
 import { z } from "zod";
 import { removeCodexTrustedPath } from "./codex-trust.js";
 import type { PitchConfig, RepoConfig } from "./config.js";
 import {
-  buildVmAgentHostMarkerPath,
   deriveAgentPaneProcess,
+  isVmAgentActiveOnHost,
   resolveExecutionEnvironment,
   resolveWorkspacePaths,
 } from "./execution-environment.js";
@@ -193,15 +192,6 @@ const SHELL_COMMANDS = new Set([
   "zsh",
 ]);
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function tryGracefulAgentShutdown(
   workspace: WorkspaceRecord,
   dependencies: WorkspaceLifecycleDependencies,
@@ -232,11 +222,7 @@ async function tryGracefulAgentShutdown(
 
   if (
     workspace.environment_kind === "vm-ssh" &&
-    !(
-      await pathExists(
-        buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
-      )
-    )
+    !(await isVmAgentActiveOnHost(workspace.worktree_path, workspace.name))
   ) {
     return;
   }
@@ -262,13 +248,7 @@ async function tryGracefulAgentShutdown(
       });
 
       if (workspace.environment_kind === "vm-ssh") {
-        if (
-          !(
-            await pathExists(
-              buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
-            )
-          )
-        ) {
+        if (!(await isVmAgentActiveOnHost(workspace.worktree_path, workspace.name))) {
           return;
         }
       } else if (SHELL_COMMANDS.has(updatedPaneInfo.current_command)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,16 @@ const BootstrapPromptTemplatesSchema = z
   })
   .strict();
 
+const PaneCommandsSchema = z
+  .object({
+    top_right: z.preprocess(nullToUndefined, NonEmptyTrimmedStringSchema.optional()),
+    bottom_right: z.preprocess(
+      nullToUndefined,
+      NonEmptyTrimmedStringSchema.optional(),
+    ),
+  })
+  .strict();
+
 const SharedPathModeSchema = z.enum(["ro", "rw"]);
 
 const SharedPathSchema = z.object({
@@ -123,6 +133,10 @@ const RepoConfigSchema = z
     bootstrap_prompts: z.preprocess(
       nullToUndefined,
       BootstrapPromptTemplatesSchema.default({}),
+    ),
+    pane_commands: z.preprocess(
+      nullToUndefined,
+      PaneCommandsSchema.default({}),
     ),
     agent_defaults: z.preprocess(
       nullToUndefined,
@@ -247,6 +261,7 @@ export interface RepoConfig {
   tmux_session: string;
   additional_paths: string[];
   bootstrap_prompts: BootstrapPromptTemplates;
+  pane_commands?: PaneCommands;
   agent_defaults: AgentOverride;
   agent_overrides: Record<string, AgentOverride>;
 }
@@ -254,6 +269,11 @@ export interface RepoConfig {
 export interface BootstrapPromptTemplates {
   issue?: string;
   pr?: string;
+}
+
+export interface PaneCommands {
+  top_right?: string;
+  bottom_right?: string;
 }
 
 export interface AgentConfig {
@@ -352,6 +372,7 @@ function normalizeRepoConfig(
     tmux_session: repoConfig.tmux_session ?? deriveTmuxSession(repoName),
     additional_paths: repoConfig.additional_paths,
     bootstrap_prompts: repoConfig.bootstrap_prompts,
+    pane_commands: repoConfig.pane_commands,
     agent_defaults: repoConfig.agent_defaults,
     agent_overrides: repoConfig.agent_overrides,
   };

--- a/src/create-workspace.ts
+++ b/src/create-workspace.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { access } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { z } from "zod";
 import {
@@ -20,7 +19,7 @@ import {
 import { runGitHubLifecycle } from "./github-lifecycle.js";
 import { readPullRequest } from "./github-pr.js";
 import {
-  buildVmAgentHostMarkerPath,
+  isVmAgentActiveOnHost,
   mapAdditionalPathsForEnvironment,
   mapPathForEnvironment,
   resolveExecutionEnvironment,
@@ -555,15 +554,6 @@ const SHELL_COMMANDS = new Set([
   "zsh",
 ]);
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function classifyExistingPane(
   currentCommand: string,
   agentCommand: BuiltAgentCommand,
@@ -576,10 +566,9 @@ async function classifyExistingPane(
 
   if (currentCommand === agentCommand.pane_process_name) {
     if (agentCommand.environment_kind === "vm-ssh") {
-      const markerPath =
-        agentCommand.host_marker_path ??
-        buildVmAgentHostMarkerPath(worktreePath, workspaceName);
-      return (await pathExists(markerPath)) ? "agent" : "connected-shell";
+      return (await isVmAgentActiveOnHost(worktreePath, workspaceName))
+        ? "agent"
+        : "connected-shell";
     }
 
     return "agent";

--- a/src/create-workspace.ts
+++ b/src/create-workspace.ts
@@ -14,7 +14,7 @@ import { ensureCodexTrustedPath } from "./codex-trust.js";
 import {
   ensureWorkspaceWorktree,
   fetchGitRef,
-  GitWorktreeError,
+  findManagedWorktreeForBranch,
   removeWorktree,
 } from "./git.js";
 import { runGitHubLifecycle } from "./github-lifecycle.js";
@@ -38,9 +38,11 @@ import {
   killTmuxWindow,
   sendKeysToPane,
   tmuxWindowExists,
+  type TmuxPaneLayout,
 } from "./tmux.js";
 import {
   deleteWorkspaceRecord,
+  getWorkspaceWorktreeName,
   listWorkspaceRecords,
   readWorkspaceRecord,
   WorkspaceRecordSchema,
@@ -50,6 +52,7 @@ import {
 import { buildWorkspaceToolResponse } from "./workspace-tool-response.js";
 import { formatAgentPaneCommand } from "./agent-pane-command.js";
 import { ensureOpencodeConfig } from "./opencode-config.js";
+import { sendConfiguredPaneCommands } from "./pane-commands.js";
 import { shellEscape } from "./shell.js";
 
 export const CreateWorkspaceInputSchema = z
@@ -64,7 +67,8 @@ export const CreateWorkspaceInputSchema = z
       .regex(
         /^[a-z0-9][a-z0-9-]*$/,
         "Slug must use lowercase letters, numbers, and hyphens",
-      ),
+      )
+      .optional(),
     base_branch: z.string().trim().min(1).optional(),
     agent: z.string().trim().min(1).optional(),
     environment: z.string().trim().min(1).optional(),
@@ -100,6 +104,7 @@ export interface CreateWorkspaceDependencies {
   deleteWorkspaceRecord: typeof deleteWorkspaceRecord;
   ensureWorkspaceWorktree: typeof ensureWorkspaceWorktree;
   fetchGitRef: typeof fetchGitRef;
+  findManagedWorktreeForBranch: typeof findManagedWorktreeForBranch;
   removeWorktree: typeof removeWorktree;
   readPullRequest: typeof readPullRequest;
   ensureTmuxSession: typeof ensureTmuxSession;
@@ -129,6 +134,7 @@ export class CreateWorkspaceError extends Error {
 
 interface RollbackState {
   workspace_name: string;
+  worktree_name: string;
   repo_config: RepoConfig;
   worktree_created: boolean;
   tmux_window_created: boolean;
@@ -165,6 +171,7 @@ const defaultDependencies: CreateWorkspaceDependencies = {
   deleteWorkspaceRecord,
   ensureWorkspaceWorktree,
   fetchGitRef,
+  findManagedWorktreeForBranch,
   removeWorktree,
   readPullRequest,
   ensureTmuxSession,
@@ -257,12 +264,20 @@ function resolveAgentName(
   return resolved;
 }
 
-function buildIssueWorkspaceName(issue: number, slug: string): string {
-  return `gh-${issue}-${slug}`;
+function appendSlug(baseName: string, slug?: string): string {
+  return slug === undefined ? baseName : `${baseName}-${slug}`;
 }
 
-function buildPullRequestWorkspaceName(pr: number, slug: string): string {
-  return `pr-${pr}-${slug}`;
+function buildIssueWorkspaceName(issue: number, slug?: string): string {
+  return appendSlug(`gh-${issue}`, slug);
+}
+
+function buildPullRequestWorkspaceName(pr: number, slug?: string): string {
+  return appendSlug(`pr-${pr}`, slug);
+}
+
+function buildPullRequestWorktreeName(pr: number): string {
+  return `pr-${pr}`;
 }
 
 function buildRequestedWorkspaceName(input: CreateWorkspaceInput): string {
@@ -277,32 +292,81 @@ function buildRequestedWorkspaceName(input: CreateWorkspaceInput): string {
   throw new CreateWorkspaceError("Provide exactly one of issue or pr");
 }
 
-async function ensureNoTrackedPullRequestWorkspace(
-  input: CreateWorkspaceInput,
+function matchesReusablePullRequestCheckout(
+  workspace: WorkspaceRecord,
   repoName: string,
   workspaceName: string,
+  branch: string,
+): boolean {
+  return (
+    workspace.repo === repoName &&
+    workspace.name !== workspaceName &&
+    workspace.branch === branch
+  );
+}
+
+async function resolveWorktreeName(
+  source: ResolvedWorkspaceSource,
+  repoName: string,
+  repoConfig: RepoConfig,
   dependencies: CreateWorkspaceDependencies,
-): Promise<void> {
-  if (input.pr === undefined) {
-    return;
+): Promise<{
+  worktree_name: string;
+  reused_workspace?: WorkspaceRecord;
+  reused_worktree_name?: string;
+}> {
+  if (source.source_kind !== "pr") {
+    return {
+      worktree_name: source.workspace_name,
+    };
   }
 
   const existingWorkspaces = await dependencies.listWorkspaceRecords({
     repo: repoName,
     status: "all",
   });
-  const existingPullRequestWorkspace = existingWorkspaces.find(
-    (workspace) =>
-      workspace.source_kind === "pr" &&
-      workspace.source_number === input.pr &&
-      workspace.name !== workspaceName,
+  const reusableWorkspace =
+    existingWorkspaces.find(
+      (workspace) =>
+        workspace.status === "active" &&
+        matchesReusablePullRequestCheckout(
+          workspace,
+          repoName,
+          source.workspace_name,
+          source.branch,
+        ),
+    ) ??
+    existingWorkspaces.find((workspace) =>
+      matchesReusablePullRequestCheckout(
+        workspace,
+        repoName,
+        source.workspace_name,
+        source.branch,
+      ),
+    );
+
+  if (reusableWorkspace !== undefined) {
+    return {
+      worktree_name: getWorkspaceWorktreeName(reusableWorkspace),
+      reused_workspace: reusableWorkspace,
+    };
+  }
+
+  const reusableManagedWorktree = await dependencies.findManagedWorktreeForBranch(
+    repoConfig,
+    source.branch,
   );
 
-  if (existingPullRequestWorkspace !== undefined) {
-    throw new CreateWorkspaceError(
-      `PR #${input.pr} already has a tracked workspace: ${existingPullRequestWorkspace.name}`,
-    );
+  if (reusableManagedWorktree !== null) {
+    return {
+      worktree_name: reusableManagedWorktree.workspace_name,
+      reused_worktree_name: reusableManagedWorktree.workspace_name,
+    };
   }
+
+  return {
+    worktree_name: buildPullRequestWorktreeName(source.source_number),
+  };
 }
 
 async function resolveWorkspaceSource(
@@ -417,18 +481,6 @@ function buildAgentSessions(
   ];
 }
 
-function shouldRetryPullRequestWithWorkspaceBranch(
-  source: ResolvedWorkspaceSource,
-  error: unknown,
-): error is GitWorktreeError {
-  return (
-    source.source_kind === "pr" &&
-    source.branch !== source.workspace_name &&
-    error instanceof GitWorktreeError &&
-    error.code === "BRANCH_IN_USE"
-  );
-}
-
 async function maybeEnsureOpencodeConfig(
   config: PitchConfig,
   repoName: string,
@@ -515,6 +567,7 @@ async function pathExists(path: string): Promise<boolean> {
 async function classifyExistingPane(
   currentCommand: string,
   agentCommand: BuiltAgentCommand,
+  workspaceName: string,
   worktreePath: string,
 ): Promise<ExistingPaneState["kind"] | "unsupported"> {
   if (SHELL_COMMANDS.has(currentCommand)) {
@@ -524,7 +577,8 @@ async function classifyExistingPane(
   if (currentCommand === agentCommand.pane_process_name) {
     if (agentCommand.environment_kind === "vm-ssh") {
       const markerPath =
-        agentCommand.host_marker_path ?? buildVmAgentHostMarkerPath(worktreePath);
+        agentCommand.host_marker_path ??
+        buildVmAgentHostMarkerPath(worktreePath, workspaceName);
       return (await pathExists(markerPath)) ? "agent" : "connected-shell";
     }
 
@@ -567,11 +621,11 @@ async function rollbackCreateWorkspace(
     try {
       await dependencies.removeWorktree({
         repo: state.repo_config,
-        workspace_name: state.workspace_name,
+        workspace_name: state.worktree_name,
       });
     } catch (error: unknown) {
       cleanupErrors.push(
-        `Failed to remove worktree ${state.workspace_name}: ${formatError(error)}`,
+        `Failed to remove worktree ${state.worktree_name}: ${formatError(error)}`,
       );
     }
   }
@@ -597,6 +651,7 @@ export async function createWorkspace(
 
   const rollbackState: RollbackState = {
     workspace_name: workspaceName,
+    worktree_name: workspaceName,
     repo_config: repoConfig,
     worktree_created: false,
     tmux_window_created: false,
@@ -609,13 +664,6 @@ export async function createWorkspace(
       throw new CreateWorkspaceError(`Workspace already exists: ${workspaceName}`);
     }
 
-    await ensureNoTrackedPullRequestWorkspace(
-      input,
-      repoName,
-      workspaceName,
-      dependencies,
-    );
-
     const source = await resolveWorkspaceSource(
       input,
       repoName,
@@ -623,31 +671,31 @@ export async function createWorkspace(
       config,
       dependencies,
     );
+    const worktreeTarget = await resolveWorktreeName(
+      source,
+      repoName,
+      repoConfig,
+      dependencies,
+    );
+    rollbackState.worktree_name = worktreeTarget.worktree_name;
 
-    let worktree;
-    try {
-      worktree = await dependencies.ensureWorkspaceWorktree({
-        repo: repoConfig,
-        workspace_name: workspaceName,
-        branch: source.branch,
-        start_point: source.start_point,
-      });
-    } catch (error: unknown) {
-      if (!shouldRetryPullRequestWithWorkspaceBranch(source, error)) {
-        throw error;
-      }
-
+    if (worktreeTarget.reused_workspace !== undefined) {
       reportWarnings(dependencies.reportWarning, [
-        `PR head branch ${source.branch} is already checked out in another worktree; using workspace branch ${source.workspace_name} instead.`,
+        `PR head branch ${source.branch} is already tracked by workspace ${worktreeTarget.reused_workspace.name}; reusing worktree ${worktreeTarget.worktree_name}.`,
       ]);
-
-      worktree = await dependencies.ensureWorkspaceWorktree({
-        repo: repoConfig,
-        workspace_name: workspaceName,
-        branch: source.workspace_name,
-        start_point: source.start_point,
-      });
+    } else if (worktreeTarget.reused_worktree_name !== undefined) {
+      reportWarnings(dependencies.reportWarning, [
+        `PR head branch ${source.branch} is already checked out in managed worktree ${worktreeTarget.reused_worktree_name}; adopting that worktree.`,
+      ]);
     }
+
+    const worktree = await dependencies.ensureWorkspaceWorktree({
+      repo: repoConfig,
+      workspace_name: worktreeTarget.worktree_name,
+      branch: source.branch,
+      start_point: source.start_point,
+      ...(source.source_kind === "pr" ? { allow_branch_reuse: true } : {}),
+    });
     rollbackState.worktree_created = !worktree.adopted;
 
     await dependencies.ensureTmuxSession({
@@ -662,7 +710,7 @@ export async function createWorkspace(
     );
     const workspacePaths = resolveWorkspacePaths(
       environment,
-      workspaceName,
+      worktreeTarget.worktree_name,
       worktree.worktree_path,
     );
 
@@ -738,6 +786,7 @@ export async function createWorkspace(
 
     let existingPane: ExistingPaneState | null = null;
     let agentPaneId: string;
+    let createdPanes: TmuxPaneLayout | null = null;
     const windowExists = await dependencies.tmuxWindowExists(
       repoConfig.tmux_session,
       workspaceName,
@@ -752,6 +801,7 @@ export async function createWorkspace(
       const paneKind = await classifyExistingPane(
         paneInfo.current_command,
         agentCommand,
+        workspaceName,
         worktree.worktree_path,
       );
 
@@ -788,12 +838,14 @@ export async function createWorkspace(
         window_name: workspaceName,
         worktree_path: worktree.worktree_path,
       });
+      createdPanes = layout.panes;
       agentPaneId = layout.panes.agent_pane_id;
     }
 
     const timestamp = dependencies.now().toISOString();
     const workspaceRecord: WorkspaceRecord = {
       name: workspaceName,
+      worktree_name: worktreeTarget.worktree_name,
       repo: repoName,
       source_kind: source.source_kind,
       source_number: source.source_number,
@@ -853,6 +905,18 @@ export async function createWorkspace(
           ]);
         }
       }
+    }
+
+    if (createdPanes !== null) {
+      await sendConfiguredPaneCommands(
+        workspaceName,
+        repoConfig.pane_commands,
+        createdPanes,
+        {
+          sendKeysToPane: dependencies.sendKeysToPane,
+          reportWarning: dependencies.reportWarning,
+        },
+      );
     }
 
     try {

--- a/src/execution-environment.ts
+++ b/src/execution-environment.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join, posix, relative, resolve, sep } from "node:path";
+import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import type {
   AgentRuntime,
   ExecutionEnvironmentConfig,
@@ -28,8 +28,20 @@ export interface VmAgentStatePaths {
   guest_marker_path: string;
 }
 
-export function buildVmAgentHostMarkerPath(worktreePath: string): string {
-  return join(worktreePath, ".pitch", "vm-agent-active");
+export function buildVmAgentHostMarkerPath(
+  worktreePath: string,
+  workspaceName: string,
+): string {
+  return join(
+    dirname(worktreePath),
+    ".pitch-state",
+    workspaceName,
+    "vm-agent-active",
+  );
+}
+
+function buildLegacyVmAgentGuestMarkerPath(worktreePath: string): string {
+  return posix.join(worktreePath, ".pitch", "vm-agent-active");
 }
 
 export class ExecutionEnvironmentError extends Error {
@@ -307,15 +319,18 @@ function buildUserLocalPathSnippet(): string {
 }
 
 export function buildVmAgentStatePaths(
+  workspaceName: string,
   workspacePaths: Pick<ResolvedWorkspacePaths, "host_worktree_path" | "guest_worktree_path">,
 ): VmAgentStatePaths {
   return {
     host_marker_path: buildVmAgentHostMarkerPath(
       workspacePaths.host_worktree_path,
+      workspaceName,
     ),
     guest_marker_path: posix.join(
-      workspacePaths.guest_worktree_path,
-      ".pitch",
+      posix.dirname(workspacePaths.guest_worktree_path),
+      ".pitch-state",
+      workspaceName,
       "vm-agent-active",
     ),
   };
@@ -324,13 +339,15 @@ export function buildVmAgentStatePaths(
 function buildVmAgentExecutionSnippet(
   remoteCommand: string,
   guestMarkerPath: string,
+  legacyGuestMarkerPath: string,
 ): string {
   const guestMarkerDir = posix.dirname(guestMarkerPath);
 
   return [
     `mkdir -p -- ${shellEscape(guestMarkerDir)}`,
-    `cleanup() { rm -f -- ${shellEscape(guestMarkerPath)}; }`,
+    `cleanup() { rm -f -- ${shellEscape(guestMarkerPath)} ${shellEscape(legacyGuestMarkerPath)}; }`,
     "trap cleanup EXIT INT TERM",
+    `rm -f -- ${shellEscape(legacyGuestMarkerPath)}`,
     `: > ${shellEscape(guestMarkerPath)}`,
     `${remoteCommand}`,
     "status=$?",
@@ -342,6 +359,7 @@ function buildVmAgentExecutionSnippet(
 
 export interface VmSshCommandInput {
   environment: VmSshExecutionEnvironmentConfig;
+  workspace_name: string;
   workspace_paths: Pick<ResolvedWorkspacePaths, "host_worktree_path" | "guest_worktree_path">;
   agent_command: string[];
   agent_env: Record<string, string>;
@@ -357,7 +375,10 @@ export function buildVmSshCommand(
   pane_process_name: string;
 } {
   const sshTarget = buildVmSshTarget(input.environment);
-  const statePaths = buildVmAgentStatePaths(input.workspace_paths);
+  const statePaths = buildVmAgentStatePaths(
+    input.workspace_name,
+    input.workspace_paths,
+  );
   const remoteEnv = Object.entries(input.agent_env).map(([key, value]) =>
     formatEnvAssignment(key, value),
   );
@@ -374,7 +395,11 @@ export function buildVmSshCommand(
     `${buildUserLocalPathSnippet()} && ` +
     `cd -- ${shellEscape(input.workspace_paths.guest_worktree_path)} && ` +
     `${bootstrapSnippet}clear && ` +
-    `${buildVmAgentExecutionSnippet(remoteCommand, statePaths.guest_marker_path)}`;
+    `${buildVmAgentExecutionSnippet(
+      remoteCommand,
+      statePaths.guest_marker_path,
+      buildLegacyVmAgentGuestMarkerPath(input.workspace_paths.guest_worktree_path),
+    )}`;
   const remoteSessionScript = `${remoteAgentScript}; exec bash -li`;
 
   const command = ["ssh", "-tt"];

--- a/src/execution-environment.ts
+++ b/src/execution-environment.ts
@@ -1,3 +1,4 @@
+import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import type {
@@ -40,8 +41,39 @@ export function buildVmAgentHostMarkerPath(
   );
 }
 
+export function buildLegacyVmAgentHostMarkerPath(worktreePath: string): string {
+  return join(worktreePath, ".pitch", "vm-agent-active");
+}
+
 function buildLegacyVmAgentGuestMarkerPath(worktreePath: string): string {
   return posix.join(worktreePath, ".pitch", "vm-agent-active");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isVmAgentActiveOnHost(
+  worktreePath: string,
+  workspaceName: string,
+): Promise<boolean> {
+  const markerPaths = [
+    buildVmAgentHostMarkerPath(worktreePath, workspaceName),
+    buildLegacyVmAgentHostMarkerPath(worktreePath),
+  ];
+
+  for (const markerPath of markerPaths) {
+    if (await pathExists(markerPath)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export class ExecutionEnvironmentError extends Error {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 import { access, mkdir, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { RepoConfig } from "./config.js";
@@ -21,17 +21,21 @@ export interface EnsureWorkspaceWorktreeParams {
   workspace_name: string;
   branch: string;
   start_point: string;
+  allow_branch_reuse?: boolean;
 }
 
 export interface RemoveWorktreeParams {
   repo: GitRepoConfig;
   workspace_name: string;
+  worktree_path?: string;
+  force?: boolean;
 }
 
 export interface RestoreWorktreeParams {
   repo: GitRepoConfig;
   workspace_name: string;
   branch: string;
+  allow_branch_reuse?: boolean;
 }
 
 export interface FetchGitRefParams {
@@ -42,9 +46,18 @@ export interface FetchGitRefParams {
   destination_ref: string;
 }
 
+export interface FastForwardWorktreeParams {
+  worktree_path: string;
+  target_ref: string;
+}
+
 export interface WorktreeResult {
   branch: string;
   worktree_path: string;
+}
+
+export interface ManagedWorktreeMatch extends WorktreeResult {
+  workspace_name: string;
 }
 
 export interface EnsuredWorktreeResult extends WorktreeResult {
@@ -238,6 +251,91 @@ async function listRegisteredWorktrees(mainWorktree: string): Promise<string[]> 
   }
 }
 
+async function isRegisteredWorktree(
+  mainWorktree: string,
+  worktreePath: string,
+): Promise<boolean> {
+  const normalizedTarget = await normalizePath(worktreePath);
+  const registeredWorktrees = await listRegisteredWorktrees(mainWorktree);
+  const normalizedRegistered = await Promise.all(
+    registeredWorktrees.map((path) => normalizePath(path)),
+  );
+
+  return normalizedRegistered.includes(normalizedTarget);
+}
+
+async function listRegisteredWorktreeDetails(
+  mainWorktree: string,
+): Promise<Array<{ worktree_path: string; branch: string | null }>> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["worktree", "list", "--porcelain"],
+      { cwd: mainWorktree },
+    );
+
+    const entries: Array<{ worktree_path: string; branch: string | null }> = [];
+    let currentPath: string | null = null;
+    let currentBranch: string | null = null;
+
+    for (const line of stdout.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        if (currentPath !== null) {
+          entries.push({
+            worktree_path: currentPath,
+            branch: currentBranch,
+          });
+        }
+        currentPath = line.slice("worktree ".length).trim();
+        currentBranch = null;
+        continue;
+      }
+
+      if (line.startsWith("branch ")) {
+        const branchRef = line.slice("branch ".length).trim();
+        currentBranch = branchRef.startsWith("refs/heads/")
+          ? branchRef.slice("refs/heads/".length)
+          : branchRef;
+      }
+    }
+
+    if (currentPath !== null) {
+      entries.push({
+        worktree_path: currentPath,
+        branch: currentBranch,
+      });
+    }
+
+    return entries;
+  } catch (err: unknown) {
+    throw new GitWorktreeError(
+      "COMMAND_FAILED",
+      `Failed to list registered worktrees in ${mainWorktree}\n${formatGitError(err)}`,
+    );
+  }
+}
+
+function toWorkspaceNameFromManagedPath(
+  worktreeBase: string,
+  worktreePath: string,
+): string | null {
+  const relativePath = relative(worktreeBase, worktreePath);
+  if (
+    relativePath.length === 0 ||
+    relativePath.startsWith(`..${sep}`) ||
+    relativePath === ".." ||
+    relativePath.includes(sep)
+  ) {
+    return null;
+  }
+
+  try {
+    return validateWorkspaceName(relativePath);
+  } catch {
+    return null;
+  }
+}
+
 async function branchExists(
   mainWorktree: string,
   branch: string,
@@ -391,6 +489,7 @@ export async function ensureWorkspaceWorktree(
       repo: params.repo,
       workspace_name: workspaceName,
       branch,
+      allow_branch_reuse: params.allow_branch_reuse,
     });
     return {
       ...restored,
@@ -405,17 +504,74 @@ export async function ensureWorkspaceWorktree(
   };
 }
 
+export async function findManagedWorktreeForBranch(
+  repo: GitRepoConfig,
+  branch: string,
+): Promise<ManagedWorktreeMatch | null> {
+  const mainWorktree = expandHomePath(repo.main_worktree);
+  const worktreeBase = expandHomePath(repo.worktree_base);
+
+  await ensureMainWorktree(mainWorktree);
+  await ensureValidBranchName(mainWorktree, branch);
+
+  const normalizedWorktreeBase = await normalizePath(worktreeBase);
+  const worktrees = await listRegisteredWorktreeDetails(mainWorktree);
+
+  for (const worktree of worktrees) {
+    if (worktree.branch !== branch) {
+      continue;
+    }
+
+    const normalizedWorktreePath = await normalizePath(worktree.worktree_path);
+    const workspaceName = toWorkspaceNameFromManagedPath(
+      normalizedWorktreeBase,
+      normalizedWorktreePath,
+    );
+
+    if (workspaceName === null) {
+      continue;
+    }
+
+    return {
+      workspace_name: workspaceName,
+      branch,
+      worktree_path: join(worktreeBase, workspaceName),
+    };
+  }
+
+  return null;
+}
+
+export async function listWorktreesForBranch(
+  repo: Pick<GitRepoConfig, "main_worktree">,
+  branch: string,
+): Promise<WorktreeResult[]> {
+  const mainWorktree = expandHomePath(repo.main_worktree);
+
+  await ensureMainWorktree(mainWorktree);
+  await ensureValidBranchName(mainWorktree, branch);
+
+  const worktrees = await listRegisteredWorktreeDetails(mainWorktree);
+  return worktrees
+    .filter((worktree) => worktree.branch === branch)
+    .map((worktree) => ({
+      branch,
+      worktree_path: worktree.worktree_path,
+    }));
+}
+
 export async function removeWorktree(
   params: RemoveWorktreeParams,
 ): Promise<WorktreeResult> {
   const workspaceName = validateWorkspaceName(params.workspace_name);
   const mainWorktree = expandHomePath(params.repo.main_worktree);
-  const worktreePath = buildWorktreePath(params.repo, workspaceName);
+  const worktreePath = params.worktree_path === undefined
+    ? buildWorktreePath(params.repo, workspaceName)
+    : expandHomePath(params.worktree_path);
 
   await ensureMainWorktree(mainWorktree);
 
-  const registeredWorktrees = await listRegisteredWorktrees(mainWorktree);
-  if (!registeredWorktrees.includes(worktreePath)) {
+  if (!(await isRegisteredWorktree(mainWorktree, worktreePath))) {
     throw new GitWorktreeError(
       "WORKTREE_MISSING",
       `Worktree does not exist at ${worktreePath}`,
@@ -430,12 +586,65 @@ export async function removeWorktree(
       branch = workspaceName;
     }
   }
-  await runGit(["worktree", "remove", worktreePath], mainWorktree);
+
+  const removeArgs = ["worktree", "remove"];
+  if (params.force === true) {
+    removeArgs.push("--force");
+  }
+  removeArgs.push(worktreePath);
+  await runGit(removeArgs, mainWorktree);
 
   return {
     branch,
     worktree_path: worktreePath,
   };
+}
+
+export async function isWorktreeDirty(worktreePath: string): Promise<boolean> {
+  const expandedPath = expandHomePath(worktreePath);
+  if (!(await pathExists(expandedPath))) {
+    return false;
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["status", "--porcelain", "--untracked-files=all"],
+      { cwd: expandedPath },
+    );
+    return stdout.trim().length > 0;
+  } catch (err: unknown) {
+    throw new GitWorktreeError(
+      "COMMAND_FAILED",
+      `Failed to inspect worktree status at ${expandedPath}\n${formatGitError(err)}`,
+    );
+  }
+}
+
+export async function fastForwardWorktree(
+  params: FastForwardWorktreeParams,
+): Promise<void> {
+  const worktreePath = expandHomePath(params.worktree_path);
+
+  if (!(await pathExists(worktreePath))) {
+    throw new GitWorktreeError(
+      "WORKTREE_MISSING",
+      `Worktree does not exist at ${worktreePath}`,
+    );
+  }
+
+  try {
+    await execFileAsync(
+      "git",
+      ["merge", "--ff-only", params.target_ref],
+      { cwd: worktreePath },
+    );
+  } catch (err: unknown) {
+    throw new GitWorktreeError(
+      "COMMAND_FAILED",
+      `Failed to fast-forward worktree at ${worktreePath} to ${params.target_ref}\n${formatGitError(err)}`,
+    );
+  }
 }
 
 export async function fetchGitRef(
@@ -512,8 +721,12 @@ export async function restoreWorktree(
   }
 
   await mkdir(expandHomePath(params.repo.worktree_base), { recursive: true });
+  const addArgs = params.allow_branch_reuse === true
+    ? ["worktree", "add", "-f", worktreePath, branch]
+    : ["worktree", "add", worktreePath, branch];
+
   try {
-    await runGit(["worktree", "add", worktreePath, branch], mainWorktree);
+    await runGit(addArgs, mainWorktree);
   } catch (error: unknown) {
     if (isBranchInUseError(error)) {
       throw new GitWorktreeError(

--- a/src/git.ts
+++ b/src/git.ts
@@ -74,6 +74,7 @@ type GitWorktreeErrorCode =
   | "BRANCH_EXISTS"
   | "WORKTREE_EXISTS"
   | "WORKTREE_MISSING"
+  | "INVALID_WORKTREE_PATH"
   | "COMMAND_FAILED";
 
 export class GitWorktreeError extends Error {
@@ -565,11 +566,27 @@ export async function removeWorktree(
 ): Promise<WorktreeResult> {
   const workspaceName = validateWorkspaceName(params.workspace_name);
   const mainWorktree = expandHomePath(params.repo.main_worktree);
+  const expectedWorktreePath = buildWorktreePath(params.repo, workspaceName);
   const worktreePath = params.worktree_path === undefined
-    ? buildWorktreePath(params.repo, workspaceName)
+    ? expectedWorktreePath
     : expandHomePath(params.worktree_path);
 
   await ensureMainWorktree(mainWorktree);
+
+  if (params.worktree_path !== undefined) {
+    const [normalizedWorktreePath, normalizedExpectedWorktreePath] =
+      await Promise.all([
+        normalizePath(worktreePath),
+        normalizePath(expectedWorktreePath),
+      ]);
+
+    if (normalizedWorktreePath !== normalizedExpectedWorktreePath) {
+      throw new GitWorktreeError(
+        "INVALID_WORKTREE_PATH",
+        `Worktree path does not match the managed worktree for ${workspaceName}: ${worktreePath}`,
+      );
+    }
+  }
 
   if (!(await isRegisteredWorktree(mainWorktree, worktreePath))) {
     throw new GitWorktreeError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { registerCloseWorkspaceTool } from "./close-workspace.js";
+import {
+  registerCloseWorkspaceTool,
+  registerDeleteWorkspaceTool,
+} from "./close-workspace.js";
 import { ConfigError, loadConfig, type PitchConfig } from "./config.js";
 import { registerCreateWorkspaceTool } from "./create-workspace.js";
 import { getRuntimeMetadata } from "./metadata.js";
@@ -65,6 +68,7 @@ server.registerTool(
 registerCreateWorkspaceTool(server, config);
 registerWorkspaceQueryTools(server);
 registerCloseWorkspaceTool(server, config);
+registerDeleteWorkspaceTool(server, config);
 registerResumeWorkspaceTool(server, config);
 
 const transport = new StdioServerTransport();

--- a/src/pane-commands.ts
+++ b/src/pane-commands.ts
@@ -1,0 +1,56 @@
+import type { PaneCommands } from "./config.js";
+import { sendKeysToPane, type TmuxPaneLayout } from "./tmux.js";
+
+export interface PaneCommandDependencies {
+  sendKeysToPane: typeof sendKeysToPane;
+  reportWarning?: (warning: string) => void;
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export async function sendConfiguredPaneCommands(
+  workspaceName: string,
+  paneCommands: PaneCommands | undefined,
+  panes: Pick<TmuxPaneLayout, "top_right_pane_id" | "bottom_right_pane_id">,
+  dependencies: PaneCommandDependencies,
+): Promise<void> {
+  if (paneCommands === undefined) {
+    return;
+  }
+
+  const configuredCommands = [
+    {
+      pane_name: "top_right",
+      pane_id: panes.top_right_pane_id,
+      command: paneCommands.top_right,
+    },
+    {
+      pane_name: "bottom_right",
+      pane_id: panes.bottom_right_pane_id,
+      command: paneCommands.bottom_right,
+    },
+  ];
+
+  for (const configuredCommand of configuredCommands) {
+    if (configuredCommand.command === undefined) {
+      continue;
+    }
+
+    try {
+      await dependencies.sendKeysToPane({
+        pane_id: configuredCommand.pane_id,
+        command: configuredCommand.command,
+      });
+    } catch (error: unknown) {
+      dependencies.reportWarning?.(
+        `Failed to send ${configuredCommand.pane_name} pane command to ${workspaceName}: ${formatError(error)}`,
+      );
+    }
+  }
+}

--- a/src/resume-workspace.ts
+++ b/src/resume-workspace.ts
@@ -8,7 +8,6 @@ import {
   resolveAgentEnv,
   type BuiltAgentCommand,
 } from "./agent-launcher.js";
-import { buildBootstrapPrompt } from "./bootstrap-prompt.js";
 import { ensureClaudeTrustedPaths } from "./claude-trust.js";
 import type { PitchConfig } from "./config.js";
 import { ensureCodexTrustedPath } from "./codex-trust.js";
@@ -23,9 +22,16 @@ import {
   type ResolvedWorkspacePaths,
 } from "./execution-environment.js";
 import { runGitHubLifecycle } from "./github-lifecycle.js";
+import { readPullRequest } from "./github-pr.js";
 import { findOpencodeSessionForWorkspace } from "./opencode-session-store.js";
 import { sendPostLaunchPromptToPane } from "./post-launch-prompt.js";
-import { restoreWorktree } from "./git.js";
+import {
+  fastForwardWorktree,
+  fetchGitRef,
+  isWorktreeDirty,
+  listWorktreesForBranch,
+  restoreWorktree,
+} from "./git.js";
 import {
   createTmuxLayout,
   createTmuxWindow,
@@ -35,9 +41,11 @@ import {
   getTmuxWindowPane,
   sendKeysToPane,
   tmuxWindowExists,
+  type TmuxPaneLayout,
   type TmuxPaneInfo,
 } from "./tmux.js";
 import {
+  getWorkspaceWorktreeName,
   readWorkspaceRecord,
   WorkspaceRecordSchema,
   writeWorkspaceRecord,
@@ -46,11 +54,13 @@ import {
 import { buildWorkspaceToolResponse } from "./workspace-tool-response.js";
 import { formatAgentPaneCommand } from "./agent-pane-command.js";
 import { ensureOpencodeConfig } from "./opencode-config.js";
+import { sendConfiguredPaneCommands } from "./pane-commands.js";
 
 export const ResumeWorkspaceInputSchema = z.object({
   name: z.string().trim().min(1),
   agent: z.string().trim().min(1).optional(),
   environment: z.string().trim().min(1).optional(),
+  sync: z.boolean().optional(),
 }).strict();
 
 export type ResumeWorkspaceInput = z.infer<typeof ResumeWorkspaceInputSchema>;
@@ -63,9 +73,14 @@ export interface ResumeWorkspaceDependencies {
   ensureTmuxSession: typeof ensureTmuxSession;
   findCodexSessionForWorkspace: typeof findCodexSessionForWorkspace;
   findOpencodeSessionForWorkspace: typeof findOpencodeSessionForWorkspace;
+  fastForwardWorktree: typeof fastForwardWorktree;
+  fetchGitRef: typeof fetchGitRef;
   getTmuxWindowPaneInfo: typeof getTmuxWindowPaneInfo;
   getTmuxWindowPane: typeof getTmuxWindowPane;
   getTmuxPaneInfo: typeof getTmuxPaneInfo;
+  isWorktreeDirty: typeof isWorktreeDirty;
+  listWorktreesForBranch: typeof listWorktreesForBranch;
+  readPullRequest: typeof readPullRequest;
   readWorkspaceRecord: typeof readWorkspaceRecord;
   restoreWorktree: typeof restoreWorktree;
   runGitHubLifecycle: typeof runGitHubLifecycle;
@@ -86,11 +101,16 @@ const defaultDependencies: ResumeWorkspaceDependencies = {
   createTmuxLayout,
   createTmuxWindow,
   ensureTmuxSession,
+  fastForwardWorktree,
+  fetchGitRef,
   getTmuxPaneInfo,
   findCodexSessionForWorkspace,
   findOpencodeSessionForWorkspace,
   getTmuxWindowPaneInfo,
   getTmuxWindowPane,
+  isWorktreeDirty,
+  listWorktreesForBranch,
+  readPullRequest,
   readWorkspaceRecord,
   restoreWorktree,
   runGitHubLifecycle,
@@ -283,7 +303,7 @@ async function isCompatibleRunningAgentPane(
 
   if (workspace.environment_kind === "vm-ssh") {
     return pathExists(
-      buildVmAgentHostMarkerPath(workspace.worktree_path),
+      buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
     );
   }
 
@@ -311,7 +331,115 @@ async function shouldReuseConnectedVmPane(
     return false;
   }
 
-  return !(await pathExists(buildVmAgentHostMarkerPath(workspace.worktree_path)));
+  return !(
+    await pathExists(
+      buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
+    )
+  );
+}
+
+async function maybeSyncWorkspaceOnResume(
+  input: ResumeWorkspaceInput,
+  workspace: WorkspaceRecord,
+  repoConfig: PitchConfig["repos"][string],
+  hasCompatibleRunningPane: boolean,
+  dependencies: ResumeWorkspaceDependencies,
+): Promise<void> {
+  if (input.sync !== true) {
+    return;
+  }
+
+  if (workspace.source_kind !== "pr") {
+    throw new ResumeWorkspaceError(
+      `Sync on resume is only supported for PR workspaces: ${workspace.name}`,
+    );
+  }
+
+  if (hasCompatibleRunningPane) {
+    throw new ResumeWorkspaceError(
+      `Cannot sync ${workspace.name} while a compatible agent pane is already running; use normal git commands inside the workspace instead.`,
+    );
+  }
+
+  let dirty: boolean;
+  try {
+    dirty = await dependencies.isWorktreeDirty(workspace.worktree_path);
+  } catch (error: unknown) {
+    throw new ResumeWorkspaceError(
+      `Failed to inspect worktree for ${workspace.name}: ${formatError(error)}`,
+    );
+  }
+
+  if (dirty) {
+    throw new ResumeWorkspaceError(
+      `Cannot sync ${workspace.name}: worktree ${workspace.worktree_path} contains modified or untracked files.`,
+    );
+  }
+
+  let pullRequest;
+  try {
+    pullRequest = await dependencies.readPullRequest({
+      repo: workspace.repo,
+      pr_number: workspace.source_number,
+    });
+  } catch (error: unknown) {
+    throw new ResumeWorkspaceError(
+      `Failed to resolve PR #${workspace.source_number} for ${workspace.name}: ${formatError(error)}`,
+    );
+  }
+
+  if (pullRequest.head_ref_name !== workspace.branch) {
+    reportWarnings(dependencies.reportWarning, [
+      `PR #${pullRequest.number} head branch is ${pullRequest.head_ref_name}; syncing recorded branch ${workspace.branch} to the latest PR head commit.`,
+    ]);
+  }
+
+  let branchWorktrees;
+  try {
+    branchWorktrees = await dependencies.listWorktreesForBranch(
+      repoConfig,
+      workspace.branch,
+    );
+  } catch (error: unknown) {
+    throw new ResumeWorkspaceError(
+      `Failed to inspect branch worktrees for ${workspace.name}: ${formatError(error)}`,
+    );
+  }
+
+  const siblingWorktrees = branchWorktrees
+    .map((worktree) => worktree.worktree_path)
+    .filter((path) => path !== workspace.worktree_path);
+  if (siblingWorktrees.length > 0) {
+    reportWarnings(dependencies.reportWarning, [
+      `Syncing ${workspace.branch} for ${workspace.name} will also move the branch ref used by other worktrees: ${siblingWorktrees.join(", ")}.`,
+    ]);
+  }
+
+  const targetRef = `refs/pitch/pr/${workspace.source_number}/head`;
+  try {
+    await dependencies.fetchGitRef({
+      repo: repoConfig,
+      remote: "origin",
+      fallback_remote: `${new URL(pullRequest.url).origin}/${workspace.repo}.git`,
+      source_ref: `refs/pull/${workspace.source_number}/head`,
+      destination_ref: targetRef,
+    });
+  } catch (error: unknown) {
+    throw new ResumeWorkspaceError(
+      `Failed to fetch latest PR head for ${workspace.name}: ${formatError(error)}`,
+    );
+  }
+
+  try {
+    await dependencies.fastForwardWorktree({
+      worktree_path: workspace.worktree_path,
+      target_ref: targetRef,
+    });
+  } catch (error: unknown) {
+    throw new ResumeWorkspaceError(
+      `Failed to fast-forward ${workspace.name} to the latest PR head: ${formatError(error)}`,
+    );
+  }
 }
 
 async function maybeEnsureOpencodeConfig(
@@ -400,12 +528,7 @@ export async function resumeWorkspace(
   if (workspace === null) {
     throw new ResumeWorkspaceError(`Workspace not found: ${input.name}`);
   }
-
-  if (workspace.status !== "active") {
-    throw new ResumeWorkspaceError(
-      `Workspace is not active: ${workspace.name}`,
-    );
-  }
+  const wasClosed = workspace.status === "closed";
 
   const repoConfig = config.repos[workspace.repo];
   if (repoConfig === undefined) {
@@ -415,7 +538,7 @@ export async function resumeWorkspace(
   try {
     const restoredWorktree = await dependencies.restoreWorktree({
       repo: repoConfig,
-      workspace_name: workspace.name,
+      workspace_name: getWorkspaceWorktreeName(workspace),
       branch: workspace.branch,
     });
     workspace = {
@@ -441,6 +564,7 @@ export async function resumeWorkspace(
 
   let agentPaneId: string;
   let existingPaneInfo: TmuxPaneInfo | null = null;
+  let createdPanes: TmuxPaneLayout | null = null;
   try {
     const windowExists = await dependencies.tmuxWindowExists(
       workspace.tmux_session,
@@ -459,6 +583,7 @@ export async function resumeWorkspace(
           window_name: workspace.tmux_window,
           worktree_path: workspace.worktree_path,
         });
+        createdPanes = layout.panes;
         agentPaneId = layout.panes.agent_pane_id;
       } catch (error: unknown) {
         throw new ResumeWorkspaceError(
@@ -500,7 +625,7 @@ export async function resumeWorkspace(
         };
   const derivedWorkspacePaths = resolveWorkspacePaths(
     environment,
-    workspace.name,
+    getWorkspaceWorktreeName(workspace),
     workspace.worktree_path,
   );
   const workspacePaths: ResolvedWorkspacePaths = {
@@ -597,15 +722,35 @@ export async function resumeWorkspace(
     }
   }
 
+  const hasCompatibleRunningPane = await isCompatibleRunningAgentPane(
+    workspace,
+    existingPaneInfo,
+  );
+
+  await maybeSyncWorkspaceOnResume(
+    input,
+    workspace,
+    repoConfig,
+    hasCompatibleRunningPane,
+    dependencies,
+  );
+
   if (
     !isAgentContextChanged &&
     !isEnvironmentContextChanged &&
     latestSessionId === null &&
     findLatestPendingSessionIndex(workspace) === null &&
-    await isCompatibleRunningAgentPane(workspace, existingPaneInfo)
+    hasCompatibleRunningPane
   ) {
-    await dependencies.writeWorkspaceRecord(workspace);
-    return workspace;
+    const resumedWorkspace: WorkspaceRecord = wasClosed
+      ? {
+          ...workspace,
+          status: "active",
+          updated_at: dependencies.now().toISOString(),
+        }
+      : workspace;
+    await dependencies.writeWorkspaceRecord(resumedWorkspace);
+    return resumedWorkspace;
   }
 
   let command: BuiltAgentCommand;
@@ -638,13 +783,7 @@ export async function resumeWorkspace(
         workspace_name: workspace.name,
         worktree_path: workspacePaths.agent_worktree_path,
         host_worktree_path: workspacePaths.host_worktree_path,
-        initial_prompt: buildBootstrapPrompt(config, {
-          repo: workspace.repo,
-          source_kind: workspace.source_kind,
-          source_number: workspace.source_number,
-          workspace_name: workspace.name,
-          branch: workspace.branch,
-        }),
+        initial_prompt: undefined,
       });
     } else {
       command = dependencies.buildAgentResumeCommand({
@@ -652,6 +791,7 @@ export async function resumeWorkspace(
         agent: agentName,
         repo: workspace.repo,
         environment: environment.name,
+        workspace_name: workspace.name,
         opencode_config_path: opencodeConfigPath,
         session_id: latestSessionId,
         worktree_path: workspacePaths.agent_worktree_path,
@@ -734,9 +874,22 @@ export async function resumeWorkspace(
     }
   }
 
+  if (createdPanes !== null) {
+    await sendConfiguredPaneCommands(
+      workspace.name,
+      repoConfig.pane_commands,
+      createdPanes,
+      {
+        sendKeysToPane: dependencies.sendKeysToPane,
+        reportWarning: dependencies.reportWarning,
+      },
+    );
+  }
+
   const startedAt = dependencies.now().toISOString();
   const updatedWorkspace: WorkspaceRecord = {
     ...workspace,
+    status: "active",
     agent_name: command.agent_name,
     agent_type: command.agent_type,
     agent_runtime: command.runtime,
@@ -789,7 +942,7 @@ export function registerResumeWorkspaceTool(
     "resume_workspace",
     {
       description:
-        "Resume or relaunch the coding agent in an existing active workspace.",
+        "Resume or relaunch the coding agent in an existing workspace, including previously closed workspaces.",
       inputSchema: ResumeWorkspaceInputSchema,
       outputSchema: WorkspaceRecordSchema,
     },

--- a/src/resume-workspace.ts
+++ b/src/resume-workspace.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { access } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { z } from "zod";
 import {
@@ -13,8 +12,8 @@ import type { PitchConfig } from "./config.js";
 import { ensureCodexTrustedPath } from "./codex-trust.js";
 import { findCodexSessionForWorkspace } from "./codex-session-store.js";
 import {
-  buildVmAgentHostMarkerPath,
   deriveAgentPaneProcess,
+  isVmAgentActiveOnHost,
   mapAdditionalPathsForEnvironment,
   resolveExecutionEnvironment,
   resolveWorkspacePaths,
@@ -272,15 +271,6 @@ function buildNextAgentSession(
   };
 }
 
-async function pathExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function isCompatibleRunningAgentPane(
   workspace: WorkspaceRecord,
   paneInfo: TmuxPaneInfo | null,
@@ -302,9 +292,7 @@ async function isCompatibleRunningAgentPane(
   }
 
   if (workspace.environment_kind === "vm-ssh") {
-    return pathExists(
-      buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
-    );
+    return isVmAgentActiveOnHost(workspace.worktree_path, workspace.name);
   }
 
   return true;
@@ -331,11 +319,7 @@ async function shouldReuseConnectedVmPane(
     return false;
   }
 
-  return !(
-    await pathExists(
-      buildVmAgentHostMarkerPath(workspace.worktree_path, workspace.name),
-    )
-  );
+  return !(await isVmAgentActiveOnHost(workspace.worktree_path, workspace.name));
 }
 
 async function maybeSyncWorkspaceOnResume(

--- a/src/workspace-state.ts
+++ b/src/workspace-state.ts
@@ -43,6 +43,7 @@ export const AgentSessionSchema = z.object({
 
 export const WorkspaceRecordSchema = z.object({
   name: WorkspaceNameSchema,
+  worktree_name: WorkspaceNameSchema.optional(),
   repo: z.string(),
   source_kind: WorkspaceSourceKindSchema,
   source_number: z.number().int().positive(),
@@ -78,6 +79,12 @@ export type ExecutionEnvironmentKind = z.infer<
 export type WorkspaceStatus = z.infer<typeof WorkspaceStatusSchema>;
 export type WorkspaceSourceKind = z.infer<typeof WorkspaceSourceKindSchema>;
 export type ListWorkspacesOptions = z.infer<typeof ListWorkspacesOptionsSchema>;
+
+export function getWorkspaceWorktreeName(
+  workspace: Pick<WorkspaceRecord, "name"> & { worktree_name?: string },
+): string {
+  return workspace.worktree_name ?? workspace.name;
+}
 
 export class WorkspaceStateError extends Error {
   constructor(message: string) {


### PR DESCRIPTION
## Summary

Refines Pitch's deterministic workspace flow across the CLI, workspace lifecycle, PR-backed worktrees, VM-backed sessions, and pane startup behavior.

## What changed

- adds and improves the direct CLI flow, including implied `create`, optional slugs, `delete`, `resume --sync`, and dynamic zsh completion
- splits `close` from destructive cleanup, allows resuming closed workspaces, and keeps bootstrap prompts create-only
- reworks PR workspace handling so session names, branches, and shared checkouts are separated more cleanly
- fixes VM-backed agent marker handling so liveness state no longer dirties the repo checkout
- adds repo-level `pane_commands.top_right` and `pane_commands.bottom_right` commands that run when Pitch creates or recreates a tmux layout
- updates MCP tool descriptions, docs, and tests to match the new behavior

## Why

These changes make Pitch more reliable as a deterministic terminal control surface, reduce surprising workspace lifecycle behavior, and improve the default tmux workspace experience without changing the agent pane behavior.

## Validation

- `npx tsc --noEmit`
- `npm test`
- `npm run build`